### PR TITLE
test: dht

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "contributors": [],
   "dependencies": {
+    "cids": "~0.5.7",
     "execa": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dirty-chai": "^2.0.1",
     "go-libp2p-dep": "^6.0.30",
     "libp2p-daemon": "~0.2.0",
-    "libp2p-daemon-client": "~0.1.1",
+    "libp2p-daemon-client": "~0.1.2",
     "multiaddr": "^6.0.6",
     "rimraf": "^2.6.3"
   },

--- a/test/dht/README.md
+++ b/test/dht/README.md
@@ -1,0 +1,9 @@
+# DHT
+
+In this set of tests, we intend to guarantee that nodes implemented in a specific language are able to use the dht features correctly, regardless of their implementation language.
+
+This test suite is divided in three main focus:
+
+- `content-fetching` aims to test the DHT interop regarding `put` and `get` operations between peers
+- `content-routing` aims to test the DHT interop regarding `provide` and `findProviders` operations between peers
+- `peer-routing` aims to test the DHT interop regarding `findPeer` operations between peers

--- a/test/dht/content-fetching/go2go.js
+++ b/test/dht/content-fetching/go2go.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-bytes'))
+const expect = chai.expect
+
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe.skip('dht.contentFetching', () => {
+  let daemons
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(2, 'go')
+
+    // connect them
+    const identify0 = await daemons[0].client.identify()
+
+    await daemons[1].client.connect(identify0.peerId, identify0.addrs)
+
+    // jsDaemon1 will take some time to get the peers
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('go peer to go peer', async function () {
+    this.timeout(10 * 1000)
+
+    const key = 'keyA'
+    const value = Buffer.from('hello data')
+
+    await daemons[0].client.dht.put(key, value)
+
+    const data = await daemons[1].client.dht.get(key)
+
+    expect(data).to.equalBytes(data)
+  })
+})

--- a/test/dht/content-fetching/go2go.js
+++ b/test/dht/content-fetching/go2go.js
@@ -15,7 +15,7 @@ describe.skip('dht.contentFetching', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, 'go')
+    daemons = await spawnDaemons(2, 'go', { dht: true })
 
     // connect them
     const identify0 = await daemons[0].client.identify()

--- a/test/dht/content-fetching/go2js.js
+++ b/test/dht/content-fetching/go2js.js
@@ -15,7 +15,7 @@ describe.skip('dht.contentFetching', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, ['go', 'js'])
+    daemons = await spawnDaemons(2, ['go', 'js'], { dht: true })
 
     // connect them
     const identify0 = await daemons[0].client.identify()

--- a/test/dht/content-fetching/go2js.js
+++ b/test/dht/content-fetching/go2js.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-bytes'))
+const expect = chai.expect
+
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe.skip('dht.contentFetching', () => {
+  let daemons
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(2, ['go', 'js'])
+
+    // connect them
+    const identify0 = await daemons[0].client.identify()
+
+    await daemons[1].client.connect(identify0.peerId, identify0.addrs)
+
+    // jsDaemon1 will take some time to get the peers
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('go peer to js peer', async function () {
+    this.timeout(10 * 1000)
+
+    const key = 'keyA'
+    const value = Buffer.from('hello data')
+
+    await daemons[0].client.dht.put(key, value)
+
+    const data = await daemons[1].client.dht.get(key)
+
+    expect(data).to.equalBytes(data)
+  })
+})

--- a/test/dht/content-fetching/index.js
+++ b/test/dht/content-fetching/index.js
@@ -1,0 +1,6 @@
+'use strict'
+
+require('./go2go')
+require('./go2js')
+require('./js2go')
+require('./js2js')

--- a/test/dht/content-fetching/js2go.js
+++ b/test/dht/content-fetching/js2go.js
@@ -15,7 +15,7 @@ describe.skip('dht.contentFetching', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, ['js', 'go'])
+    daemons = await spawnDaemons(2, ['js', 'go'], { dht: true })
 
     // connect them
     const identify0 = await daemons[0].client.identify()

--- a/test/dht/content-fetching/js2go.js
+++ b/test/dht/content-fetching/js2go.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-bytes'))
+const expect = chai.expect
+
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe.skip('dht.contentFetching', () => {
+  let daemons
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(2, ['js', 'go'])
+
+    // connect them
+    const identify0 = await daemons[0].client.identify()
+
+    await daemons[1].client.connect(identify0.peerId, identify0.addrs)
+
+    // jsDaemon1 will take some time to get the peers
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('js peer to go peer', async function () {
+    this.timeout(10 * 1000)
+
+    const key = 'keyA'
+    const value = Buffer.from('hello data')
+
+    await daemons[0].client.dht.put(key, value)
+
+    const data = await daemons[1].client.dht.get(key)
+
+    expect(data).to.equalBytes(data)
+  })
+})

--- a/test/dht/content-fetching/js2js.js
+++ b/test/dht/content-fetching/js2js.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-bytes'))
+const expect = chai.expect
+
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe('dht.contentFetching', () => {
+  let daemons
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(2, 'js')
+
+    // connect them
+    const identify0 = await daemons[0].client.identify()
+
+    await daemons[1].client.connect(identify0.peerId, identify0.addrs)
+
+    // jsDaemon1 will take some time to get the peers
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('js peer to js peer', async function () {
+    this.timeout(10 * 1000)
+
+    const key = 'keyA'
+    const value = Buffer.from('hello data')
+
+    await daemons[0].client.dht.put(key, value)
+
+    const data = await daemons[1].client.dht.get(key)
+
+    expect(data).to.equalBytes(data)
+  })
+})

--- a/test/dht/content-fetching/js2js.js
+++ b/test/dht/content-fetching/js2js.js
@@ -15,7 +15,7 @@ describe('dht.contentFetching', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, 'js')
+    daemons = await spawnDaemons(2, 'js', { dht: true })
 
     // connect them
     const identify0 = await daemons[0].client.identify()

--- a/test/dht/content-routing/go2go.js
+++ b/test/dht/content-routing/go2go.js
@@ -17,7 +17,7 @@ describe('dht.contentRouting', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, 'go')
+    daemons = await spawnDaemons(2, 'go', { dht: true })
 
     // connect them
     identify0 = await daemons[0].client.identify()

--- a/test/dht/content-routing/go2go.js
+++ b/test/dht/content-routing/go2go.js
@@ -36,8 +36,6 @@ describe('dht.contentRouting', () => {
   })
 
   it('go peer to go peer', async function () {
-    this.timeout(30 * 1000)
-
     const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp39')
 
     await daemons[0].client.dht.provide(cid)

--- a/test/dht/content-routing/go2go.js
+++ b/test/dht/content-routing/go2go.js
@@ -1,0 +1,56 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-bytes'))
+const expect = chai.expect
+
+const CID = require('cids')
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe('dht.contentRouting', () => {
+  let daemons
+  let identify0
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(2, 'go')
+
+    // connect them
+    identify0 = await daemons[0].client.identify()
+
+    await daemons[1].client.connect(identify0.peerId, identify0.addrs)
+
+    // get the peers in the table
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('go peer to go peer', async function () {
+    this.timeout(30 * 1000)
+
+    const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp39')
+
+    await daemons[0].client.dht.provide(cid)
+
+    const findProviders = daemons[1].client.dht.findProviders(cid)
+    let providers = []
+
+    for await (const provider of findProviders) {
+      providers.push(provider)
+    }
+
+    expect(providers).to.exist()
+    expect(providers[0]).to.exist()
+    expect(providers[0].id.toB58String()).to.equal(identify0.peerId.toB58String())
+  })
+})

--- a/test/dht/content-routing/go2js.js
+++ b/test/dht/content-routing/go2js.js
@@ -1,0 +1,56 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-bytes'))
+const expect = chai.expect
+
+const CID = require('cids')
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe('dht.contentRouting', () => {
+  let daemons
+  let identify0
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(2, ['go', 'js'])
+
+    // connect them
+    identify0 = await daemons[0].client.identify()
+
+    await daemons[1].client.connect(identify0.peerId, identify0.addrs)
+
+    // get the peers in the table
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('go peer to js peer', async function () {
+    this.timeout(30 * 1000)
+
+    const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp39')
+
+    await daemons[0].client.dht.provide(cid)
+
+    const findProviders = daemons[1].client.dht.findProviders(cid)
+    let providers = []
+
+    for await (const provider of findProviders) {
+      providers.push(provider)
+    }
+
+    expect(providers).to.exist()
+    expect(providers[0]).to.exist()
+    expect(providers[0].id.toB58String()).to.equal(identify0.peerId.toB58String())
+  })
+})

--- a/test/dht/content-routing/go2js.js
+++ b/test/dht/content-routing/go2js.js
@@ -17,7 +17,7 @@ describe('dht.contentRouting', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, ['go', 'js'])
+    daemons = await spawnDaemons(2, ['go', 'js'], { dht: true })
 
     // connect them
     identify0 = await daemons[0].client.identify()

--- a/test/dht/content-routing/go2js.js
+++ b/test/dht/content-routing/go2js.js
@@ -36,8 +36,6 @@ describe('dht.contentRouting', () => {
   })
 
   it('go peer to js peer', async function () {
-    this.timeout(30 * 1000)
-
     const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp39')
 
     await daemons[0].client.dht.provide(cid)

--- a/test/dht/content-routing/index.js
+++ b/test/dht/content-routing/index.js
@@ -1,0 +1,6 @@
+'use strict'
+
+require('./go2go')
+require('./go2js')
+require('./js2go')
+require('./js2js')

--- a/test/dht/content-routing/js2go.js
+++ b/test/dht/content-routing/js2go.js
@@ -1,0 +1,56 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-bytes'))
+const expect = chai.expect
+
+const CID = require('cids')
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe('dht.contentRouting', () => {
+  let daemons
+  let identify0
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(2, ['js', 'go'])
+
+    // connect them
+    identify0 = await daemons[0].client.identify()
+
+    await daemons[1].client.connect(identify0.peerId, identify0.addrs)
+
+    // get the peers in the table
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('go peer to js peer', async function () {
+    this.timeout(30 * 1000)
+
+    const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp39')
+
+    await daemons[0].client.dht.provide(cid)
+
+    const findProviders = daemons[1].client.dht.findProviders(cid)
+    let providers = []
+
+    for await (const provider of findProviders) {
+      providers.push(provider)
+    }
+
+    expect(providers).to.exist()
+    expect(providers[0]).to.exist()
+    expect(providers[0].id.toB58String()).to.equal(identify0.peerId.toB58String())
+  })
+})

--- a/test/dht/content-routing/js2go.js
+++ b/test/dht/content-routing/js2go.js
@@ -36,8 +36,6 @@ describe('dht.contentRouting', () => {
   })
 
   it('go peer to js peer', async function () {
-    this.timeout(30 * 1000)
-
     const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp39')
 
     await daemons[0].client.dht.provide(cid)

--- a/test/dht/content-routing/js2go.js
+++ b/test/dht/content-routing/js2go.js
@@ -17,7 +17,7 @@ describe('dht.contentRouting', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, ['js', 'go'])
+    daemons = await spawnDaemons(2, ['js', 'go'], { dht: true })
 
     // connect them
     identify0 = await daemons[0].client.identify()

--- a/test/dht/content-routing/js2js.js
+++ b/test/dht/content-routing/js2js.js
@@ -36,8 +36,6 @@ describe('dht.contentRouting', () => {
   })
 
   it('js peer to js peer', async function () {
-    this.timeout(30 * 1000)
-
     const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp39')
 
     await daemons[0].client.dht.provide(cid)

--- a/test/dht/content-routing/js2js.js
+++ b/test/dht/content-routing/js2js.js
@@ -17,7 +17,7 @@ describe('dht.contentRouting', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, 'js')
+    daemons = await spawnDaemons(2, 'js', { dht: true })
 
     // connect them
     identify0 = await daemons[0].client.identify()

--- a/test/dht/content-routing/js2js.js
+++ b/test/dht/content-routing/js2js.js
@@ -1,0 +1,56 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-bytes'))
+const expect = chai.expect
+
+const CID = require('cids')
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe('dht.contentRouting', () => {
+  let daemons
+  let identify0
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(2, 'js')
+
+    // connect them
+    identify0 = await daemons[0].client.identify()
+
+    await daemons[1].client.connect(identify0.peerId, identify0.addrs)
+
+    // get the peers in the table
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('js peer to js peer', async function () {
+    this.timeout(30 * 1000)
+
+    const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp39')
+
+    await daemons[0].client.dht.provide(cid)
+
+    const findProviders = daemons[1].client.dht.findProviders(cid)
+    let providers = []
+
+    for await (const provider of findProviders) {
+      providers.push(provider)
+    }
+
+    expect(providers).to.exist()
+    expect(providers[0]).to.exist()
+    expect(providers[0].id.toB58String()).to.equal(identify0.peerId.toB58String())
+  })
+})

--- a/test/dht/index.js
+++ b/test/dht/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+require('./content-fetching')
+require('./content-routing')
+require('./peer-routing')

--- a/test/dht/peer-routing/go2go.js
+++ b/test/dht/peer-routing/go2go.js
@@ -26,8 +26,6 @@ describe('dht.peerRouting', () => {
   })
 
   it('go peer to go peer', async function () {
-    this.timeout(10 * 1000)
-
     const identify1 = await daemons[1].client.identify()
     const identify2 = await daemons[2].client.identify()
 

--- a/test/dht/peer-routing/go2go.js
+++ b/test/dht/peer-routing/go2go.js
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-checkmark'))
+const expect = chai.expect
+
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe('dht.peerRouting', () => {
+  let daemons
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(3, 'go')
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('go peer to go peer', async function () {
+    this.timeout(10 * 1000)
+
+    const identify1 = await daemons[1].client.identify()
+    const identify2 = await daemons[2].client.identify()
+
+    // peers need at least one peer in their routing table or they fail with:
+    // connect 0 => 1
+    await daemons[0].client.connect(identify1.peerId, identify1.addrs)
+
+    // connect 0 => 2
+    await daemons[0].client.connect(identify2.peerId, identify2.addrs)
+
+    // peer 1 find peer 2
+    const peerInfo = await daemons[1].client.dht.findPeer(identify2.peerId)
+
+    expect(peerInfo.multiaddrs.toArray()).to.have.deep.members(identify2.addrs)
+  })
+})

--- a/test/dht/peer-routing/go2go.js
+++ b/test/dht/peer-routing/go2go.js
@@ -15,7 +15,7 @@ describe('dht.peerRouting', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(3, 'go')
+    daemons = await spawnDaemons(3, 'go', { dht: true })
   })
 
   // Stop daemons

--- a/test/dht/peer-routing/go2js.js
+++ b/test/dht/peer-routing/go2js.js
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-checkmark'))
+const expect = chai.expect
+
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe('dht.peerRouting', () => {
+  let daemons
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(3, ['go', 'go', 'js'])
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('go peer to js peer', async function () {
+    this.timeout(10 * 1000)
+
+    const identify1 = await daemons[1].client.identify()
+    const identify2 = await daemons[2].client.identify()
+
+    // peers need at least one peer in their routing table or they fail with:
+    // connect 0 => 1
+    await daemons[0].client.connect(identify1.peerId, identify1.addrs)
+
+    // connect 0 => 2
+    await daemons[0].client.connect(identify2.peerId, identify2.addrs)
+
+    // peer 1 find peer 2
+    const peerInfo = await daemons[1].client.dht.findPeer(identify2.peerId)
+
+    expect(peerInfo.multiaddrs.toArray()).to.have.deep.members(identify2.addrs)
+  })
+})

--- a/test/dht/peer-routing/go2js.js
+++ b/test/dht/peer-routing/go2js.js
@@ -15,7 +15,7 @@ describe('dht.peerRouting', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(3, ['go', 'go', 'js'])
+    daemons = await spawnDaemons(3, ['go', 'go', 'js'], { dht: true })
   })
 
   // Stop daemons

--- a/test/dht/peer-routing/go2js.js
+++ b/test/dht/peer-routing/go2js.js
@@ -26,8 +26,6 @@ describe('dht.peerRouting', () => {
   })
 
   it('go peer to js peer', async function () {
-    this.timeout(10 * 1000)
-
     const identify1 = await daemons[1].client.identify()
     const identify2 = await daemons[2].client.identify()
 

--- a/test/dht/peer-routing/index.js
+++ b/test/dht/peer-routing/index.js
@@ -1,0 +1,6 @@
+'use strict'
+
+require('./go2go')
+require('./go2js')
+require('./js2go')
+require('./js2js')

--- a/test/dht/peer-routing/js2go.js
+++ b/test/dht/peer-routing/js2go.js
@@ -15,7 +15,7 @@ describe('dht.peerRouting', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(3, ['js', 'js', 'go'])
+    daemons = await spawnDaemons(3, ['js', 'js', 'go'], { dht: true })
   })
 
   // Stop daemons

--- a/test/dht/peer-routing/js2go.js
+++ b/test/dht/peer-routing/js2go.js
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-checkmark'))
+const expect = chai.expect
+
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe('dht.peerRouting', () => {
+  let daemons
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(3, ['js', 'js', 'go'])
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('js peer to go peer', async function () {
+    this.timeout(10 * 1000)
+
+    const identify1 = await daemons[1].client.identify()
+    const identify2 = await daemons[2].client.identify()
+
+    // peers need at least one peer in their routing table or they fail with:
+    // connect 0 => 1
+    await daemons[0].client.connect(identify1.peerId, identify1.addrs)
+
+    // connect 0 => 2
+    await daemons[0].client.connect(identify2.peerId, identify2.addrs)
+
+    // peer 1 find peer 2
+    const peerInfo = await daemons[1].client.dht.findPeer(identify2.peerId)
+
+    expect(peerInfo.multiaddrs.toArray()).to.have.deep.members(identify2.addrs)
+  })
+})

--- a/test/dht/peer-routing/js2go.js
+++ b/test/dht/peer-routing/js2go.js
@@ -26,8 +26,6 @@ describe('dht.peerRouting', () => {
   })
 
   it('js peer to go peer', async function () {
-    this.timeout(10 * 1000)
-
     const identify1 = await daemons[1].client.identify()
     const identify2 = await daemons[2].client.identify()
 
@@ -37,6 +35,9 @@ describe('dht.peerRouting', () => {
 
     // connect 0 => 2
     await daemons[0].client.connect(identify2.peerId, identify2.addrs)
+
+    // daemons[0] will take some time to have the peers in the routing table
+    await new Promise(resolve => setTimeout(resolve, 1000))
 
     // peer 1 find peer 2
     const peerInfo = await daemons[1].client.dht.findPeer(identify2.peerId)

--- a/test/dht/peer-routing/js2js.js
+++ b/test/dht/peer-routing/js2js.js
@@ -26,8 +26,6 @@ describe('dht.peerRouting', () => {
   })
 
   it('js peer to js peer', async function () {
-    this.timeout(10 * 1000)
-
     const identify1 = await daemons[1].client.identify()
     const identify2 = await daemons[2].client.identify()
 
@@ -37,6 +35,9 @@ describe('dht.peerRouting', () => {
 
     // connect 0 => 2
     await daemons[0].client.connect(identify2.peerId, identify2.addrs)
+
+    // daemons[0] will take some time to have the peers in the routing table
+    await new Promise(resolve => setTimeout(resolve, 1000))
 
     // peer 1 find peer 2
     const peerInfo = await daemons[1].client.dht.findPeer(identify2.peerId)

--- a/test/dht/peer-routing/js2js.js
+++ b/test/dht/peer-routing/js2js.js
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-checkmark'))
+const expect = chai.expect
+
+const spawnDaemons = require('../../utils/spawnDaemons')
+
+describe('dht.peerRouting', () => {
+  let daemons
+
+  // Start Daemons
+  before(async function () {
+    this.timeout(20 * 1000)
+
+    daemons = await spawnDaemons(3, 'js')
+  })
+
+  // Stop daemons
+  after(async function () {
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
+  })
+
+  it('js peer to js peer', async function () {
+    this.timeout(10 * 1000)
+
+    const identify1 = await daemons[1].client.identify()
+    const identify2 = await daemons[2].client.identify()
+
+    // peers need at least one peer in their routing table or they fail with:
+    // connect 0 => 1
+    await daemons[0].client.connect(identify1.peerId, identify1.addrs)
+
+    // connect 0 => 2
+    await daemons[0].client.connect(identify2.peerId, identify2.addrs)
+
+    // peer 1 find peer 2
+    const peerInfo = await daemons[1].client.dht.findPeer(identify2.peerId)
+
+    expect(peerInfo.multiaddrs.toArray()).to.have.deep.members(identify2.addrs)
+  })
+})

--- a/test/dht/peer-routing/js2js.js
+++ b/test/dht/peer-routing/js2js.js
@@ -15,7 +15,7 @@ describe('dht.peerRouting', () => {
   before(async function () {
     this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(3, 'js')
+    daemons = await spawnDaemons(3, 'js', { dht: true })
   })
 
   // Stop daemons

--- a/test/node.js
+++ b/test/node.js
@@ -2,3 +2,4 @@
 
 require('./connect')
 require('./pubsub')
+require('./dht')


### PR DESCRIPTION
Added interop tests for dht regarding:

- `content-routing`
- `content-fetching`
- `peer-routing`

Needs:

- [x] [libp2p/js-libp2p-daemon#11](https://github.com/libp2p/js-libp2p-daemon/pull/11)
- [ ] [libp2p/go-libp2p-daemon#81](https://github.com/libp2p/go-libp2p-daemon/issues/81)
- [x] `libp2p/js-libp2p-daemon-client#fix/dht-find-providers` (do not know why this only works with that change though)