### PR TITLE
chore: update daemon and daemon-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,15 @@
   },
   "homepage": "https://github.com/libp2p/interop#readme",
   "devDependencies": {
-    "aegir": "^18.1.0",
+    "aegir": "^18.2.1",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "cross-env": "^5.2.0",
     "dirty-chai": "^2.0.1",
     "go-libp2p-dep": "^6.0.30",
-    "libp2p-daemon": "~0.1.2",
-    "libp2p-daemon-client": "~0.0.3",
+    "libp2p-daemon": "~0.2.0",
+    "libp2p-daemon-client": "~0.1.0",
+    "multiaddr": "^6.0.6",
     "rimraf": "^2.6.3"
   },
   "contributors": [],

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -122,12 +122,12 @@ class Daemon {
    */
   _cleanUnixSocket () {
     return new Promise((resolve, reject) => {
-      const path = this._addr.toString().split('/unix')
+      const path = this._addr.getPath()
       if (!path) {
         return resolve()
       }
 
-      rimraf(path[1], (err) => {
+      rimraf(path, (err) => {
         if (err) {
           return reject(err)
         }

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -7,20 +7,20 @@ const path = require('path')
 const rimraf = require('rimraf')
 
 const Client = require('libp2p-daemon-client')
-const { getSockPath, isWindows } = require('./utils')
+const { getMultiaddr, isWindows } = require('./utils')
 
 // process path
 const processPath = process.cwd()
 
 // go-libp2p defaults
 const goDaemon = {
-  defaultSock: getSockPath('/tmp/p2pd-go.sock'),
+  defaultAddr: getMultiaddr('/tmp/p2pd-go.sock'),
   bin: path.join('go-libp2p-dep', 'go-libp2p', isWindows ? 'p2pd.exe' : 'p2pd')
 }
 
 // js-libp2p defaults
 const jsDaemon = {
-  defaultSock: getSockPath('/tmp/p2pd-js.sock'),
+  defaultAddr: getMultiaddr('/tmp/p2pd-js.sock'),
   bin: path.join('libp2p-daemon', 'src', 'cli', 'bin.js')
 }
 
@@ -28,18 +28,19 @@ class Daemon {
   /**
    * @constructor
    * @param {String} type daemon implementation type ("go" or "js")
-   * @param {String} sock unix socket path
+   * @param {Multiaddr} addr multiaddr for the client to connect to
+   * @param {Number} port port for the client to connect to
    */
-  constructor (type, sock) {
+  constructor (type, addr, port) {
     assert(type === 'go' || type === 'js', 'invalid type received. Should be "go" or "js"')
 
     this._client = undefined
     this._type = type
     this._binPath = this._getBinPath(type)
-    this._sock = sock && getSockPath(sock)
+    this._addr = addr && getMultiaddr(addr, port)
 
-    if (!this._sock) {
-      this._sock = type === 'go' ? goDaemon.defaultSock : jsDaemon.defaultSock
+    if (!this._addr) {
+      this._addr = type === 'go' ? goDaemon.defaultAddr : jsDaemon.defaultAddr
     }
   }
 
@@ -80,7 +81,7 @@ class Daemon {
     await this._startDaemon()
 
     // start client
-    this._client = new Client(this._sock)
+    this._client = new Client(this._addr)
 
     await this._client.attach()
   }
@@ -92,7 +93,7 @@ class Daemon {
    */
   _startDaemon () {
     return new Promise((resolve, reject) => {
-      const options = this._type === 'go' ? ['-listen', `/unix${this._sock}`] : ['--sock', this._sock]
+      const options = this._type === 'go' ? ['-listen', `${this._addr}`] : ['--listen', this._addr]
       const daemon = execa(this._binPath, options)
 
       daemon.stdout.once('data', () => {
@@ -121,7 +122,12 @@ class Daemon {
    */
   _cleanUnixSocket () {
     return new Promise((resolve, reject) => {
-      rimraf(this._sock, (err) => {
+      const path = this._addr.toString().split('/unix')
+      if (!path) {
+        return resolve()
+      }
+
+      rimraf(path[1], (err) => {
         if (err) {
           return reject(err)
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@
 
 const os = require('os')
 const path = require('path')
+const ma = require('multiaddr')
 const isWindows = os.platform() === 'win32'
 
 exports.isWindows = isWindows
@@ -9,3 +10,7 @@ exports.isWindows = isWindows
 exports.getSockPath = (sockPath) => isWindows
   ? path.join('\\\\?\\pipe', sockPath)
   : path.resolve(os.tmpdir(), sockPath)
+
+exports.getMultiaddr = (sockPath, port) => isWindows
+  ? ma(`/ip4/0.0.0.0/tcp/${port || 8080}`)
+  : ma(`/unix${path.resolve(os.tmpdir(), sockPath)}`)

--- a/test/connect/go2go.js
+++ b/test/connect/go2go.js
@@ -17,7 +17,7 @@ describe('connect', () => {
     this.timeout(20 * 1000)
 
     goDaemon1 = new Daemon('go')
-    goDaemon2 = new Daemon('go', '/tmp/p2pd-go2.sock')
+    goDaemon2 = new Daemon('go', '/tmp/p2pd-go2.sock', 9090)
 
     await Promise.all([
       goDaemon1.start(),

--- a/test/connect/js2js.js
+++ b/test/connect/js2js.js
@@ -17,7 +17,7 @@ describe('connect', () => {
     this.timeout(20 * 1000)
 
     jsDaemon1 = new Daemon('js')
-    jsDaemon2 = new Daemon('js', '/tmp/p2pd-js2.sock')
+    jsDaemon2 = new Daemon('js', '/tmp/p2pd-js2.sock', 9090)
 
     await Promise.all([
       jsDaemon1.start(),


### PR DESCRIPTION
`js-libp2p-daemon` and `js-libp2p-daemon-client` were updated. Now, we use `multiaddr` to connect the daemon with the client instead of the socket path.