### PR TITLE
chore: spawn daemons utility and start options

### DIFF
--- a/test/connect/go2go.js
+++ b/test/connect/go2go.js
@@ -6,55 +6,47 @@ chai.use(require('dirty-chai'))
 chai.use(require('chai-checkmark'))
 const expect = chai.expect
 
-const Daemon = require('../../src/daemon')
+const spawnDaemons = require('../utils/spawnDaemons')
 
 describe('connect', () => {
-  let goDaemon1
-  let goDaemon2
+  let daemons
 
   // Start Daemons
   before(async function () {
     this.timeout(20 * 1000)
 
-    goDaemon1 = new Daemon('go')
-    goDaemon2 = new Daemon('go', '/tmp/p2pd-go2.sock', 9090)
-
-    await Promise.all([
-      goDaemon1.start(),
-      goDaemon2.start()
-    ])
+    daemons = await spawnDaemons(2, 'go')
   })
 
   // Stop daemons
   after(async function () {
-    await Promise.all([
-      goDaemon1.stop(),
-      goDaemon2.stop()
-    ])
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
   })
 
   it('go peer to go peer', async function () {
     this.timeout(10 * 1000)
 
-    const identify1 = await goDaemon1.client.identify()
-    const identify2 = await goDaemon2.client.identify()
+    const identify1 = await daemons[0].client.identify()
+    const identify2 = await daemons[1].client.identify()
 
     // verify connected peers
-    const knownPeersBeforeConnect1 = await goDaemon1.client.listPeers()
+    const knownPeersBeforeConnect1 = await daemons[0].client.listPeers()
     expect(knownPeersBeforeConnect1).to.have.lengthOf(0)
 
-    const knownPeersBeforeConnect2 = await goDaemon2.client.listPeers()
+    const knownPeersBeforeConnect2 = await daemons[1].client.listPeers()
     expect(knownPeersBeforeConnect2).to.have.lengthOf(0)
 
     // connect peers
-    await goDaemon2.client.connect(identify1.peerId, identify1.addrs)
+    await daemons[1].client.connect(identify1.peerId, identify1.addrs)
 
     // verify connected peers
-    const knownPeersAfterConnect1 = await goDaemon1.client.listPeers()
+    const knownPeersAfterConnect1 = await daemons[0].client.listPeers()
     expect(knownPeersAfterConnect1).to.have.lengthOf(1)
     expect(knownPeersAfterConnect1[0].toB58String()).to.equal(identify2.peerId.toB58String())
 
-    const knownPeersAfterConnect2 = await goDaemon2.client.listPeers()
+    const knownPeersAfterConnect2 = await daemons[1].client.listPeers()
     expect(knownPeersAfterConnect2).to.have.lengthOf(1)
     expect(knownPeersAfterConnect2[0].toB58String()).to.equal(identify1.peerId.toB58String())
   })

--- a/test/connect/go2js.js
+++ b/test/connect/go2js.js
@@ -6,55 +6,47 @@ chai.use(require('dirty-chai'))
 chai.use(require('chai-checkmark'))
 const expect = chai.expect
 
-const Daemon = require('../../src/daemon')
+const spawnDaemons = require('../utils/spawnDaemons')
 
 describe('connect', () => {
-  let goDaemon
-  let jsDaemon
+  let daemons
 
   // Start Daemons
   before(async function () {
     this.timeout(20 * 1000)
 
-    goDaemon = new Daemon('go')
-    jsDaemon = new Daemon('js')
-
-    await Promise.all([
-      goDaemon.start(),
-      jsDaemon.start()
-    ])
+    daemons = await spawnDaemons(2, ['go', 'js'])
   })
 
   // Stop daemons
   after(async function () {
-    await Promise.all([
-      goDaemon.stop(),
-      jsDaemon.stop()
-    ])
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
   })
 
   it('go peer to js peer', async function () {
     this.timeout(10 * 1000)
 
-    const identifyJs = await jsDaemon.client.identify()
-    const identifyGo = await goDaemon.client.identify()
+    const identifyJs = await daemons[0].client.identify()
+    const identifyGo = await daemons[1].client.identify()
 
     // verify connected peers
-    const knownPeersBeforeConnectJs = await jsDaemon.client.listPeers()
+    const knownPeersBeforeConnectJs = await daemons[0].client.listPeers()
     expect(knownPeersBeforeConnectJs).to.have.lengthOf(0)
 
-    const knownPeersBeforeConnectGo = await goDaemon.client.listPeers()
+    const knownPeersBeforeConnectGo = await daemons[1].client.listPeers()
     expect(knownPeersBeforeConnectGo).to.have.lengthOf(0)
 
     // connect peers
-    await goDaemon.client.connect(identifyJs.peerId, identifyJs.addrs)
+    await daemons[1].client.connect(identifyJs.peerId, identifyJs.addrs)
 
     // verify connected peers
-    const knownPeersAfterConnectGo = await goDaemon.client.listPeers()
+    const knownPeersAfterConnectGo = await daemons[1].client.listPeers()
     expect(knownPeersAfterConnectGo).to.have.lengthOf(1)
     expect(knownPeersAfterConnectGo[0].toB58String()).to.equal(identifyJs.peerId.toB58String())
 
-    const knownPeersAfterConnectJs = await jsDaemon.client.listPeers()
+    const knownPeersAfterConnectJs = await daemons[0].client.listPeers()
     expect(knownPeersAfterConnectJs).to.have.lengthOf(1)
     expect(knownPeersAfterConnectJs[0].toB58String()).to.equal(identifyGo.peerId.toB58String())
   })

--- a/test/connect/js2go.js
+++ b/test/connect/js2go.js
@@ -6,55 +6,47 @@ chai.use(require('dirty-chai'))
 chai.use(require('chai-checkmark'))
 const expect = chai.expect
 
-const Daemon = require('../../src/daemon')
+const spawnDaemons = require('../utils/spawnDaemons')
 
 describe('connect', () => {
-  let jsDaemon
-  let goDaemon
+  let daemons
 
   // Start Daemons
   before(async function () {
     this.timeout(20 * 1000)
 
-    jsDaemon = new Daemon('js')
-    goDaemon = new Daemon('go')
-
-    await Promise.all([
-      jsDaemon.start(),
-      goDaemon.start()
-    ])
+    daemons = await spawnDaemons(2, ['js', 'go'])
   })
 
   // Stop daemons
   after(async function () {
-    await Promise.all([
-      jsDaemon.stop(),
-      goDaemon.stop()
-    ])
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
   })
 
   it('js peer to go peer', async function () {
     this.timeout(10 * 1000)
 
-    const identifyJs = await jsDaemon.client.identify()
-    const identifyGo = await goDaemon.client.identify()
+    const identifyJs = await daemons[0].client.identify()
+    const identifyGo = await daemons[1].client.identify()
 
     // verify connected peers
-    const knownPeersBeforeConnectJs = await jsDaemon.client.listPeers()
+    const knownPeersBeforeConnectJs = await daemons[0].client.listPeers()
     expect(knownPeersBeforeConnectJs).to.have.lengthOf(0)
 
-    const knownPeersBeforeConnectGo = await goDaemon.client.listPeers()
+    const knownPeersBeforeConnectGo = await daemons[1].client.listPeers()
     expect(knownPeersBeforeConnectGo).to.have.lengthOf(0)
 
     // connect peers
-    await jsDaemon.client.connect(identifyGo.peerId, identifyGo.addrs)
+    await daemons[0].client.connect(identifyGo.peerId, identifyGo.addrs)
 
     // verify connected peers
-    const knownPeersAfterConnectJs = await jsDaemon.client.listPeers()
+    const knownPeersAfterConnectJs = await daemons[0].client.listPeers()
     expect(knownPeersAfterConnectJs).to.have.lengthOf(1)
     expect(knownPeersAfterConnectJs[0].toB58String()).to.equal(identifyGo.peerId.toB58String())
 
-    const knownPeersAfterConnectGo = await goDaemon.client.listPeers()
+    const knownPeersAfterConnectGo = await daemons[1].client.listPeers()
     expect(knownPeersAfterConnectGo).to.have.lengthOf(1)
     expect(knownPeersAfterConnectGo[0].toB58String()).to.equal(identifyJs.peerId.toB58String())
   })

--- a/test/connect/js2js.js
+++ b/test/connect/js2js.js
@@ -6,58 +6,50 @@ chai.use(require('dirty-chai'))
 chai.use(require('chai-checkmark'))
 const expect = chai.expect
 
-const Daemon = require('../../src/daemon')
+const spawnDaemons = require('../utils/spawnDaemons')
 
 describe('connect', () => {
-  let jsDaemon1
-  let jsDaemon2
+  let daemons
 
   // Start Daemons
   before(async function () {
     this.timeout(20 * 1000)
 
-    jsDaemon1 = new Daemon('js')
-    jsDaemon2 = new Daemon('js', '/tmp/p2pd-js2.sock', 9090)
-
-    await Promise.all([
-      jsDaemon1.start(),
-      jsDaemon2.start()
-    ])
+    daemons = await spawnDaemons(2, 'go')
   })
 
   // Stop daemons
   after(async function () {
-    await Promise.all([
-      jsDaemon1.stop(),
-      jsDaemon2.stop()
-    ])
+    await Promise.all(
+      daemons.map((daemon) => daemon.stop())
+    )
   })
 
   it('js peer to js peer', async function () {
     this.timeout(10 * 1000)
 
-    const identify1 = await jsDaemon1.client.identify()
-    const identify2 = await jsDaemon2.client.identify()
+    const identify1 = await daemons[0].client.identify()
+    const identify2 = await daemons[1].client.identify()
 
     // verify connected peers
-    const knownPeersBeforeConnect1 = await jsDaemon1.client.listPeers()
+    const knownPeersBeforeConnect1 = await daemons[0].client.listPeers()
     expect(knownPeersBeforeConnect1).to.have.lengthOf(0)
 
-    const knownPeersBeforeConnect2 = await jsDaemon2.client.listPeers()
+    const knownPeersBeforeConnect2 = await daemons[1].client.listPeers()
     expect(knownPeersBeforeConnect2).to.have.lengthOf(0)
 
     // connect peers
-    await jsDaemon2.client.connect(identify1.peerId, identify1.addrs)
+    await daemons[1].client.connect(identify1.peerId, identify1.addrs)
 
-    // jsDaemon1 will take some time to get the peers
+    // daemons[0] will take some time to get the peers
     await new Promise(resolve => setTimeout(resolve, 1000))
 
     // verify connected peers
-    const knownPeersAfterConnect1 = await jsDaemon1.client.listPeers()
+    const knownPeersAfterConnect1 = await daemons[0].client.listPeers()
     expect(knownPeersAfterConnect1).to.have.lengthOf(1)
     expect(knownPeersAfterConnect1[0].toB58String()).to.equal(identify2.peerId.toB58String())
 
-    const knownPeersAfterConnect2 = await jsDaemon2.client.listPeers()
+    const knownPeersAfterConnect2 = await daemons[1].client.listPeers()
     expect(knownPeersAfterConnect2).to.have.lengthOf(1)
     expect(knownPeersAfterConnect2[0].toB58String()).to.equal(identify1.peerId.toB58String())
   })

--- a/test/utils/spawnDaemons.js
+++ b/test/utils/spawnDaemons.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const assert = require('assert')
+
+const Daemon = require('../../src/daemon')
+
+const startPortNumber = 9000
+
+/**
+ * @param {number} n number of nodes to spawn
+ * @param {string|array} type nodes type (default: js)
+ * @param {Object|array} options daemon options
+ */
+async function spawnDaemons (n, type = 'js', options) {
+  assert(n, 'spawnDaemons require a number of nodes to start')
+  assert(validType(n, type), 'spawnDaemons type is not valid')
+
+  let types = type
+
+  if (!Array.isArray(types)) {
+    types = new Array(n).fill(type)
+  }
+
+  let daemonOptions = options
+
+  if (!Array.isArray(daemonOptions)) {
+    daemonOptions = new Array(n).fill(options)
+  }
+
+  const daemons = []
+  let daemon
+
+  for (let i = 0; i < n; i++) {
+    daemon = new Daemon(types[i], `/tmp/p2pd-${i}.sock`, startPortNumber + i)
+    daemons.push(daemon)
+  }
+
+  await Promise.all(daemons.map((daemon, i) => daemon.start(daemonOptions[i])))
+
+  return daemons
+}
+
+function validType (n, type) {
+  // validate string type
+  if (typeof type === 'string' && (type === 'js' || type === 'go')) {
+    return true
+  }
+
+  // validate array of types
+  if (Array.isArray(type) && type.length === n &&
+    !type.filter((t) => (t !== 'go' && t !== 'js')).length) {
+    return true
+  }
+
+  return false
+}
+
+module.exports = spawnDaemons


### PR DESCRIPTION
Refactor for having a spawn daemons utility, as well as allow to pass options for starting a daemon.

This code is currently replicated in the `dht` and `pubsub` PRs and it is also needed for the `circuit` and `stream` tests.