### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
   },
   "homepage": "https://github.com/libp2p/interop#readme",
   "devDependencies": {
-    "aegir": "^18.2.1",
+    "aegir": "^19.0.3",
     "chai": "^4.2.0",
     "chai-bytes": "~0.1.2",
     "chai-checkmark": "^1.0.1",
     "cross-env": "^5.2.0",
     "dirty-chai": "^2.0.1",
-    "go-libp2p-dep": "^6.0.30",
-    "libp2p-daemon": "~0.2.0",
+    "go-libp2p-dep": "~0.1.0",
+    "libp2p-daemon": "~0.2.1",
     "libp2p-daemon-client": "~0.1.2",
     "multiaddr": "^6.0.6",
     "rimraf": "^2.6.3"


### PR DESCRIPTION
Update dependencies, including the new version of `go-libp2p`.

Needs:

- [ ] [libp2p/npm-go-libp2p-dep#6](https://github.com/libp2p/npm-go-libp2p-dep/pull/6)