### PR TITLE
chore: remove commitlint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ jobs:
   include:
     - stage: check
       script:
-        - npx aegir commitlint --travis
         - npx aegir dep-check
         - npm run lint
 


### PR DESCRIPTION
Removing commitlint in favor of squash merge commit cleaning. This removes a barrier to entry for new contributors creating PRs and having those PRs run CI tests