### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dirty-chai": "^2.0.1",
     "go-libp2p-dep": "~0.1.0",
     "libp2p-daemon": "~0.2.1",
-    "libp2p-daemon-client": "~0.1.2",
+    "libp2p-daemon-client": "~0.2.1",
     "multiaddr": "^6.0.6",
     "rimraf": "^2.6.3"
   },

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -119,8 +119,11 @@ class Daemon {
       daemon.stdout.once('data', () => {
         return resolve()
       })
-      daemon.stderr.once('data', (data) => {
-        return reject(data.toString())
+
+      daemon.stderr.on('data', (data) => {
+        if (!data.toString().includes('Warning')) {
+          return reject(data.toString())
+        }
       })
     })
   }


### PR DESCRIPTION
Dependencies were updated.

A new dependency is throwing a warning `ExperimentalWarning: The fs.promises API is experimental`, which was stopping the daemon immediately after being started. In this context, I added a validation to check if we received a warning and ignore it