### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "cross-env": "^6.0.3",
     "dirty-chai": "^2.0.1",
     "go-libp2p-dep": "~0.5.0",
-    "libp2p-daemon": "libp2p/js-libp2p-daemon#refactor/streams-fix",
-    "libp2p-daemon-client": "libp2p/js-libp2p-daemon-client#chore/update-deps-20191203",
+    "libp2p-daemon": "^0.3.0",
+    "libp2p-daemon-client": "^0.3.0",
     "multiaddr": "^7.2.1",
     "rimraf": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/libp2p/interop#readme",
   "devDependencies": {
-    "aegir": "^20.4.1",
+    "aegir": "^20.5.1",
     "chai": "^4.2.0",
     "chai-bytes": "~0.1.2",
     "chai-checkmark": "^1.0.1",
@@ -43,6 +43,6 @@
   "dependencies": {
     "cids": "~0.7.1",
     "debug": "^4.1.1",
-    "execa": "^1.0.0"
+    "execa": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,21 +27,22 @@
   },
   "homepage": "https://github.com/libp2p/interop#readme",
   "devDependencies": {
-    "aegir": "^20.0.0",
+    "aegir": "^20.4.1",
     "chai": "^4.2.0",
     "chai-bytes": "~0.1.2",
     "chai-checkmark": "^1.0.1",
-    "cross-env": "^5.2.1",
+    "cross-env": "^6.0.3",
     "dirty-chai": "^2.0.1",
     "go-libp2p-dep": "~0.5.0",
-    "libp2p-daemon": "~0.2.3",
-    "libp2p-daemon-client": "~0.2.2",
-    "multiaddr": "^7.0.0",
-    "rimraf": "^2.6.3"
+    "libp2p-daemon": "libp2p/js-libp2p-daemon#refactor/streams-fix",
+    "libp2p-daemon-client": "libp2p/js-libp2p-daemon-client#chore/update-deps-20191203",
+    "multiaddr": "^7.2.1",
+    "rimraf": "^3.0.0"
   },
   "contributors": [],
   "dependencies": {
-    "cids": "~0.6.0",
+    "cids": "~0.7.1",
+    "debug": "^4.1.1",
     "execa": "^1.0.0"
   }
 }

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const debug = require('debug')
+const log = debug('daemon')
+
 const assert = require('assert')
 const execa = require('execa')
 const fs = require('fs')
@@ -85,8 +88,6 @@ class Daemon {
 
     // start client
     this._client = new Client(this._addr)
-
-    await this._client.attach()
   }
 
   /**
@@ -122,6 +123,10 @@ class Daemon {
 
       daemon.stdout.once('data', () => {
         resolve()
+
+        daemon.stdout.on('data', (data) => {
+          log(data.toString())
+        })
       })
       daemon.on('exit', (code, signal) => {
         if (code !== 0) {


### PR DESCRIPTION
This PR updates the `js-libp2p` to the new version after the async refactor.

It also sends the process stdout logs to the `daemon` debug now.

Needs:

- [x] https://github.com/libp2p/js-libp2p-daemon/pull/29
- [x] https://github.com/libp2p/js-libp2p-daemon-client/pull/18