### PR TITLE
chore: add release scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Interoperability Tests for libp2p",
   "leadMaintainer": "Vasco Santos <santos.vasco10@gmail.com>",
   "main": "",
+  "files": [
+    "test",
+    "src"
+  ],
   "engines": {
     "node": ">=10.0.0",
     "npm": ">6.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint": "aegir lint",
     "test": "aegir test -t node -f test/node.js",
     "test:node": "aegir test -t node -f test/node.js",
-    "test:browser": "aegir test -t browser --no-cors -f test/browser.js"
+    "test:browser": "aegir test -t browser --no-cors -f test/browser.js",
+    "release": "aegir release --target node",
+    "release-minor": "aegir release --type minor --target node"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add interop release scripts, so that we start releasing this module to be used as a `devDependency` in `js-libp2p`. This allows us to run interop tests on `js-libp2p` CI, in the same way as `js-ipfs` is doing.

Needs to be released, so that `js-libp2p` can use it

Needs

- [x] `js-libp2p-daemon` release