### PR TITLE
chore: update libp2p daemon with peer-store

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "dirty-chai": "^2.0.1",
     "go-libp2p-dep": "~0.8.1",
     "libp2p-daemon": "libp2p/js-libp2p-daemon#chore/update-peer-store-api",
-    "libp2p-daemon-client": "^0.3.0",
+    "libp2p-daemon-client": "libp2p/js-libp2p-daemon-client#chore/remove-peer-info-from-api",
     "multiaddr": "^7.2.1",
     "rimraf": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "cross-env": "^7.0.0",
     "dirty-chai": "^2.0.1",
     "go-libp2p-dep": "~0.8.1",
-    "libp2p-daemon": "libp2p/js-libp2p-daemon#chore/update-peer-store-api",
-    "libp2p-daemon-client": "libp2p/js-libp2p-daemon-client#chore/remove-peer-info-from-api",
+    "libp2p-daemon": "^0.4.0",
+    "libp2p-daemon-client": "^0.4.0",
     "multiaddr": "^7.2.1",
     "rimraf": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cross-env": "^7.0.0",
     "dirty-chai": "^2.0.1",
     "go-libp2p-dep": "~0.8.1",
-    "libp2p-daemon": "^0.3.1",
+    "libp2p-daemon": "libp2p/js-libp2p-daemon#chore/update-peer-store-api",
     "libp2p-daemon-client": "^0.3.0",
     "multiaddr": "^7.2.1",
     "rimraf": "^3.0.0"

--- a/test/dht/peer-routing/go2go.js
+++ b/test/dht/peer-routing/go2go.js
@@ -37,8 +37,8 @@ describe('dht.peerRouting', () => {
     await daemons[0].client.connect(identify2.peerId, identify2.addrs)
 
     // peer 1 find peer 2
-    const peerInfo = await daemons[1].client.dht.findPeer(identify2.peerId)
+    const peerData = await daemons[1].client.dht.findPeer(identify2.peerId)
 
-    expect(peerInfo.multiaddrs.toArray()).to.have.deep.members(identify2.addrs)
+    expect(peerData.addrs).to.have.deep.members(identify2.addrs)
   })
 })

--- a/test/dht/peer-routing/go2js.js
+++ b/test/dht/peer-routing/go2js.js
@@ -37,8 +37,8 @@ describe('dht.peerRouting', () => {
     await daemons[0].client.connect(identify2.peerId, identify2.addrs)
 
     // peer 1 find peer 2
-    const peerInfo = await daemons[1].client.dht.findPeer(identify2.peerId)
+    const peerData = await daemons[1].client.dht.findPeer(identify2.peerId)
 
-    expect(identify2.addrs).to.include.deep.members(peerInfo.multiaddrs.toArray())
+    expect(identify2.addrs).to.include.deep.members(peerData.addrs)
   })
 })

--- a/test/dht/peer-routing/js2go.js
+++ b/test/dht/peer-routing/js2go.js
@@ -40,8 +40,8 @@ describe('dht.peerRouting', () => {
     await new Promise(resolve => setTimeout(resolve, 1000))
 
     // peer 1 find peer 2
-    const peerInfo = await daemons[1].client.dht.findPeer(identify2.peerId)
+    const peerData = await daemons[1].client.dht.findPeer(identify2.peerId)
 
-    expect(identify2.addrs).to.include.deep.members(peerInfo.multiaddrs.toArray())
+    expect(identify2.addrs).to.include.deep.members(peerData.addrs)
   })
 })

--- a/test/dht/peer-routing/js2js.js
+++ b/test/dht/peer-routing/js2js.js
@@ -40,8 +40,8 @@ describe('dht.peerRouting', () => {
     await new Promise(resolve => setTimeout(resolve, 1000))
 
     // peer 1 find peer 2
-    const peerInfo = await daemons[1].client.dht.findPeer(identify2.peerId)
+    const peerData = await daemons[1].client.dht.findPeer(identify2.peerId)
 
-    expect(peerInfo.multiaddrs.toArray()).to.have.deep.members(identify2.addrs)
+    expect(peerData.addrs).to.have.deep.members(identify2.addrs)
   })
 })


### PR DESCRIPTION
In the context of the PeerStore improvements specified on [libp2p/js-libp2p#582](https://github.com/libp2p/js-libp2p/issues/582) and as a follow up of [libp2p/js-libp2p#590](https://github.com/libp2p/js-libp2p/pull/590).

This PR contains two commits, one for updating the `peer-store` API and a second one to use the new `libp2p` API with no `peer-info`

The modules changed (`libp2p` and `libp2p-kad-dht`) were updated.

Needs:

- [x] [libp2p/js-libp2p#590](https://github.com/libp2p/js-libp2p/pull/590)
- [x] [libp2p/js-libp2p-kad-dht#179](https://github.com/libp2p/js-libp2p-kad-dht/pull/179)
- [x] [libp2p/js-libp2p#598](https://github.com/libp2p/js-libp2p/pull/598)
- [x] [libp2p/js-libp2p#610](https://github.com/libp2p/js-libp2p/pull/610)
- [x] [libp2p/js-libp2p-daemon#38](https://github.com/libp2p/js-libp2p-daemon/pull/38)