### PR TITLE
feat: add connect tests using secio and noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,23 @@ This repository will be used for interop tests.
 > npm test
 ```
 
-### Test with a non yet released version of js-ipfs
+#### Testing local daemons
 
-TODO
+It is possible to test local versions of the go and js daemons exporting the respective path before running the tests.
 
-### Test with a non yet released version of go-ipfs
+**Specifying the go-libp2p daemon**
+See the go-libp2p-daemon [install instructions](https://github.com/libp2p/go-libp2p-daemon#install) for building the local binary.
 
-TODO
+```sh
+$ LIBP2P_GO_BIN=$GOPATH/bin/p2pd npm run test
+```
+
+**Specifying the js-libp2p daemon**
+From the js-libp2p-daemon local repo checkout you can perform an `npm link` to create a binary, `jsp2pd` in the global npm space.
+
+```sh
+$ LIBP2P_JS_BIN=$(which jsp2pd) npm run test
+```
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cross-env": "^7.0.0",
     "dirty-chai": "^2.0.1",
     "go-libp2p-dep": "~0.8.1",
-    "libp2p-daemon": "^0.3.0",
+    "libp2p-daemon": "^0.3.1",
     "libp2p-daemon-client": "^0.3.0",
     "multiaddr": "^7.2.1",
     "rimraf": "^3.0.0"

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -132,9 +132,7 @@ class Daemon {
       }
 
       const daemon = execa(this._binPath, execOptions)
-      if (process.env.DEBUG) {
-        daemon.stderr.pipe(process.stderr)
-      }
+      daemon.stderr.pipe(process.stderr)
 
       daemon.stdout.once('data', () => {
         resolve()

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -10,7 +10,7 @@ const path = require('path')
 const rimraf = require('rimraf')
 
 const Client = require('libp2p-daemon-client')
-const { getMultiaddr, isWindows } = require('./utils')
+const { getMultiaddr, isWindows, DEFAULT_CONFIG } = require('./utils')
 
 // process path
 const processPath = process.cwd()
@@ -18,13 +18,13 @@ const processPath = process.cwd()
 // go-libp2p defaults
 const goDaemon = {
   defaultAddr: getMultiaddr('/tmp/p2pd-go.sock'),
-  bin: path.join('go-libp2p-dep', 'go-libp2p', isWindows ? 'p2pd.exe' : 'p2pd')
+  bin: process.env.LIBP2P_GO_BIN || path.join('go-libp2p-dep', 'go-libp2p', isWindows ? 'p2pd.exe' : 'p2pd')
 }
 
 // js-libp2p defaults
 const jsDaemon = {
   defaultAddr: getMultiaddr('/tmp/p2pd-js.sock'),
-  bin: path.join('libp2p-daemon', 'src', 'cli', 'bin.js')
+  bin: process.env.LIBP2P_JS_BIN || path.join('libp2p-daemon', 'src', 'cli', 'bin.js')
 }
 
 class Daemon {
@@ -55,6 +55,10 @@ class Daemon {
    */
   _getBinPath (type) {
     const depPath = type === 'go' ? goDaemon.bin : jsDaemon.bin
+    if (fs.existsSync(depPath)) {
+      return depPath
+    }
+
     let npmPath = path.join(processPath, '../', depPath)
 
     if (fs.existsSync(npmPath)) {
@@ -99,6 +103,8 @@ class Daemon {
    * @returns {Promise}
    */
   _startDaemon (options) {
+    options = { ...DEFAULT_CONFIG, ...options }
+
     return new Promise((resolve, reject) => {
       let execOptions
       const addr = this._addr.toString()
@@ -107,12 +113,16 @@ class Daemon {
       if (this._type === 'go') {
         execOptions = ['-listen', addr]
 
+        execOptions.push(`-secio=${options.secio}`)
+        execOptions.push(`-noise=${options.noise}`)
         options.dht && execOptions.push('-dht')
         options.pubsub && execOptions.push('-pubsub')
         options.pubsubRouter && execOptions.push('-pubsubRouter', options.pubsubRouter)
       } else {
         execOptions = ['--listen', addr]
 
+        execOptions.push(`--secio=${options.secio}`)
+        execOptions.push(`--noise=${options.noise}`)
         options.dht && execOptions.push('--dht')
         options.pubsub && execOptions.push('--pubsub')
         options.pubsubRouter && execOptions.push('--pubsubRouter', options.pubsubRouter)
@@ -122,6 +132,9 @@ class Daemon {
       }
 
       const daemon = execa(this._binPath, execOptions)
+      if (process.env.DEBUG) {
+        daemon.stderr.pipe(process.stderr)
+      }
 
       daemon.stdout.once('data', () => {
         resolve()

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,3 +14,9 @@ exports.getSockPath = (sockPath) => isWindows
 exports.getMultiaddr = (sockPath, port) => isWindows
   ? ma(`/ip4/0.0.0.0/tcp/${port || 8080}`)
   : ma(`/unix${path.resolve(os.tmpdir(), sockPath)}`)
+
+exports.DEFAULT_CONFIG = {
+  secio: true,
+  noise: false,
+  dht: false
+}

--- a/test/connect/ed25519/go2js.js
+++ b/test/connect/ed25519/go2js.js
@@ -4,30 +4,32 @@
 const connectTest = require('../test')
 const spawnDaemons = require('../../utils/spawnDaemons')
 
-describe('connect (ed25519)', () => {
-  let daemons
+module.exports = (name, config) => {
+  describe(`connect (ed25519) using ${name}`, () => {
+    let daemons
 
-  // Start Daemons
-  before(async function () {
-    this.timeout(20 * 1000)
+    // Start Daemons
+    before(async function () {
+      this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, [
-      { type: 'go', keyType: 'ed25519' },
-      { type: 'js', keyType: 'ed25519' }
-    ])
+      daemons = await spawnDaemons(2, [
+        { type: 'go', keyType: 'ed25519' },
+        { type: 'js', keyType: 'ed25519' }
+      ], config)
+    })
+
+    // Stop daemons
+    after(async function () {
+      await Promise.all(
+        daemons.map((daemon) => daemon.stop())
+      )
+    })
+
+    it('go peer to js peer', function () {
+      this.timeout(10 * 1000)
+
+      const ids = ['12D3KooWRqGdmFVwspgLBajUQacY1TrkBkAUqmjqjbHSFGEoZs9R', '12D3KooWDaHkRyb4Nkf8L6WHbsWB9Krt491NDk8PaPGogXvj2pcY']
+      return connectTest(daemons, ids)
+    })
   })
-
-  // Stop daemons
-  after(async function () {
-    await Promise.all(
-      daemons.map((daemon) => daemon.stop())
-    )
-  })
-
-  it('go peer to js peer', function () {
-    this.timeout(10 * 1000)
-
-    const ids = ['12D3KooWRqGdmFVwspgLBajUQacY1TrkBkAUqmjqjbHSFGEoZs9R', '12D3KooWDaHkRyb4Nkf8L6WHbsWB9Krt491NDk8PaPGogXvj2pcY']
-    return connectTest(daemons, ids)
-  })
-})
+}

--- a/test/connect/ed25519/index.js
+++ b/test/connect/ed25519/index.js
@@ -1,4 +1,9 @@
 'use strict'
 
-require('./go2js')
-require('./js2go')
+// SECIO
+require('./go2js')('secio', { secio: true, noise: false })
+require('./js2go')('secio', { secio: true, noise: false })
+
+// NOISE
+require('./go2js')('noise', { secio: false, noise: true })
+require('./js2go')('noise', { secio: false, noise: true })

--- a/test/connect/ed25519/js2go.js
+++ b/test/connect/ed25519/js2go.js
@@ -4,30 +4,32 @@
 const connectTest = require('../test')
 const spawnDaemons = require('../../utils/spawnDaemons')
 
-describe('connect (ed25519)', () => {
-  let daemons
+module.exports = (name, config) => {
+  describe(`connect (ed25519) using ${name}`, () => {
+    let daemons
 
-  // Start Daemons
-  before(async function () {
-    this.timeout(20 * 1000)
+    // Start Daemons
+    before(async function () {
+      this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, [
-      { type: 'js', keyType: 'ed25519' },
-      { type: 'go', keyType: 'ed25519' }
-    ])
+      daemons = await spawnDaemons(2, [
+        { type: 'js', keyType: 'ed25519' },
+        { type: 'go', keyType: 'ed25519' }
+      ], config)
+    })
+
+    // Stop daemons
+    after(async function () {
+      await Promise.all(
+        daemons.map((daemon) => daemon.stop())
+      )
+    })
+
+    it('js peer to go peer', function () {
+      this.timeout(10 * 1000)
+
+      const ids = ['12D3KooWDaHkRyb4Nkf8L6WHbsWB9Krt491NDk8PaPGogXvj2pcY', '12D3KooWRqGdmFVwspgLBajUQacY1TrkBkAUqmjqjbHSFGEoZs9R']
+      return connectTest(daemons, ids)
+    })
   })
-
-  // Stop daemons
-  after(async function () {
-    await Promise.all(
-      daemons.map((daemon) => daemon.stop())
-    )
-  })
-
-  it('js peer to go peer', function () {
-    this.timeout(10 * 1000)
-
-    const ids = ['12D3KooWDaHkRyb4Nkf8L6WHbsWB9Krt491NDk8PaPGogXvj2pcY', '12D3KooWRqGdmFVwspgLBajUQacY1TrkBkAUqmjqjbHSFGEoZs9R']
-    return connectTest(daemons, ids)
-  })
-})
+}

--- a/test/connect/rsa/go2js.js
+++ b/test/connect/rsa/go2js.js
@@ -4,30 +4,32 @@
 const connectTest = require('../test')
 const spawnDaemons = require('../../utils/spawnDaemons')
 
-describe('connect (RSA)', () => {
-  let daemons
+module.exports = (name, config) => {
+  describe(`connect (RSA) using ${name}`, () => {
+    let daemons
 
-  // Start Daemons
-  before(async function () {
-    this.timeout(20 * 1000)
+    // Start Daemons
+    before(async function () {
+      this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, [
-      { type: 'go', keyType: 'rsa' },
-      { type: 'js', keyType: 'rsa' }
-    ])
+      daemons = await spawnDaemons(2, [
+        { type: 'go', keyType: 'rsa' },
+        { type: 'js', keyType: 'rsa' }
+      ], config)
+    })
+
+    // Stop daemons
+    after(async function () {
+      await Promise.all(
+        daemons.map((daemon) => daemon.stop())
+      )
+    })
+
+    it('go peer to js peer', function () {
+      this.timeout(10 * 1000)
+
+      const ids = ['QmWS3xmxj1i659VUoustPU8KGzXkziqzF7BBGXS9fDwyz1', 'QmPFdSzvgd1HbZSd6oX2N2vCSnhSEeocbQZsMB42UG8smE']
+      return connectTest(daemons, ids)
+    })
   })
-
-  // Stop daemons
-  after(async function () {
-    await Promise.all(
-      daemons.map((daemon) => daemon.stop())
-    )
-  })
-
-  it('go peer to js peer', function () {
-    this.timeout(10 * 1000)
-
-    const ids = ['QmWS3xmxj1i659VUoustPU8KGzXkziqzF7BBGXS9fDwyz1', 'QmPFdSzvgd1HbZSd6oX2N2vCSnhSEeocbQZsMB42UG8smE']
-    return connectTest(daemons, ids)
-  })
-})
+}

--- a/test/connect/rsa/index.js
+++ b/test/connect/rsa/index.js
@@ -1,4 +1,9 @@
 'use strict'
 
-require('./go2js')
-require('./js2go')
+// SECIO
+require('./go2js')('secio', { secio: true, noise: false })
+require('./js2go')('secio', { secio: true, noise: false })
+
+// NOISE
+require('./go2js')('noise', { secio: false, noise: true })
+require('./js2go')('noise', { secio: false, noise: true })

--- a/test/connect/rsa/js2go.js
+++ b/test/connect/rsa/js2go.js
@@ -4,30 +4,32 @@
 const connectTest = require('../test')
 const spawnDaemons = require('../../utils/spawnDaemons')
 
-describe('connect (RSA)', () => {
-  let daemons
+module.exports = (name, config) => {
+  describe(`connect (RSA) using ${name}`, () => {
+    let daemons
 
-  // Start Daemons
-  before(async function () {
-    this.timeout(20 * 1000)
+    // Start Daemons
+    before(async function () {
+      this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, [
-      { type: 'js', keyType: 'rsa' },
-      { type: 'go', keyType: 'rsa' }
-    ])
+      daemons = await spawnDaemons(2, [
+        { type: 'js', keyType: 'rsa' },
+        { type: 'go', keyType: 'rsa' }
+      ], config)
+    })
+
+    // Stop daemons
+    after(async function () {
+      await Promise.all(
+        daemons.map((daemon) => daemon.stop())
+      )
+    })
+
+    it('js peer to go peer', function () {
+      this.timeout(10 * 1000)
+
+      const ids = ['QmPFdSzvgd1HbZSd6oX2N2vCSnhSEeocbQZsMB42UG8smE', 'QmWS3xmxj1i659VUoustPU8KGzXkziqzF7BBGXS9fDwyz1']
+      return connectTest(daemons, ids)
+    })
   })
-
-  // Stop daemons
-  after(async function () {
-    await Promise.all(
-      daemons.map((daemon) => daemon.stop())
-    )
-  })
-
-  it('js peer to go peer', function () {
-    this.timeout(10 * 1000)
-
-    const ids = ['QmPFdSzvgd1HbZSd6oX2N2vCSnhSEeocbQZsMB42UG8smE', 'QmWS3xmxj1i659VUoustPU8KGzXkziqzF7BBGXS9fDwyz1']
-    return connectTest(daemons, ids)
-  })
-})
+}

--- a/test/connect/secp256k1/go2js.js
+++ b/test/connect/secp256k1/go2js.js
@@ -4,30 +4,32 @@
 const connectTest = require('../test')
 const spawnDaemons = require('../../utils/spawnDaemons')
 
-describe('connect (secp256k1)', () => {
-  let daemons
+module.exports = (name, config) => {
+  describe(`connect (secp256k1) using ${name}`, () => {
+    let daemons
 
-  // Start Daemons
-  before(async function () {
-    this.timeout(20 * 1000)
+    // Start Daemons
+    before(async function () {
+      this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, [
-      { type: 'go', keyType: 'secp256k1' },
-      { type: 'js', keyType: 'secp256k1' }
-    ])
+      daemons = await spawnDaemons(2, [
+        { type: 'go', keyType: 'secp256k1' },
+        { type: 'js', keyType: 'secp256k1' }
+      ], config)
+    })
+
+    // Stop daemons
+    after(async function () {
+      await Promise.all(
+        daemons.map((daemon) => daemon.stop())
+      )
+    })
+
+    it('go peer to js peer', function () {
+      this.timeout(10 * 1000)
+
+      const ids = ['16Uiu2HAmPu9PZESp4keskcfDkdBvDhs1Dra1aLjfeHRCFHgQoD6L', '16Uiu2HAm7txvwZbeK5g3oB3DrRhnARTEjTNorVreWJomfHJHbEu2']
+      return connectTest(daemons, ids)
+    })
   })
-
-  // Stop daemons
-  after(async function () {
-    await Promise.all(
-      daemons.map((daemon) => daemon.stop())
-    )
-  })
-
-  it('go peer to js peer', function () {
-    this.timeout(10 * 1000)
-
-    const ids = ['16Uiu2HAmPu9PZESp4keskcfDkdBvDhs1Dra1aLjfeHRCFHgQoD6L', '16Uiu2HAm7txvwZbeK5g3oB3DrRhnARTEjTNorVreWJomfHJHbEu2']
-    return connectTest(daemons, ids)
-  })
-})
+}

--- a/test/connect/secp256k1/index.js
+++ b/test/connect/secp256k1/index.js
@@ -1,4 +1,9 @@
 'use strict'
 
-require('./go2js')
-require('./js2go')
+// SECIO
+require('./go2js')('secio', { secio: true, noise: false })
+require('./js2go')('secio', { secio: true, noise: false })
+
+// NOISE
+require('./go2js')('noise', { secio: false, noise: true })
+require('./js2go')('noise', { secio: false, noise: true })

--- a/test/connect/secp256k1/js2go.js
+++ b/test/connect/secp256k1/js2go.js
@@ -4,30 +4,32 @@
 const connectTest = require('../test')
 const spawnDaemons = require('../../utils/spawnDaemons')
 
-describe('connect (secp256k1)', () => {
-  let daemons
+module.exports = (name, config) => {
+  describe(`connect (secp256k1) using ${name}`, () => {
+    let daemons
 
-  // Start Daemons
-  before(async function () {
-    this.timeout(20 * 1000)
+    // Start Daemons
+    before(async function () {
+      this.timeout(20 * 1000)
 
-    daemons = await spawnDaemons(2, [
-      { type: 'js', keyType: 'secp256k1' },
-      { type: 'go', keyType: 'secp256k1' }
-    ])
+      daemons = await spawnDaemons(2, [
+        { type: 'js', keyType: 'secp256k1' },
+        { type: 'go', keyType: 'secp256k1' }
+      ], config)
+    })
+
+    // Stop daemons
+    after(async function () {
+      await Promise.all(
+        daemons.map((daemon) => daemon.stop())
+      )
+    })
+
+    it('js peer to go peer', function () {
+      this.timeout(10 * 1000)
+
+      const ids = ['16Uiu2HAm7txvwZbeK5g3oB3DrRhnARTEjTNorVreWJomfHJHbEu2', '16Uiu2HAmPu9PZESp4keskcfDkdBvDhs1Dra1aLjfeHRCFHgQoD6L']
+      return connectTest(daemons, ids)
+    })
   })
-
-  // Stop daemons
-  after(async function () {
-    await Promise.all(
-      daemons.map((daemon) => daemon.stop())
-    )
-  })
-
-  it('js peer to go peer', function () {
-    this.timeout(10 * 1000)
-
-    const ids = ['16Uiu2HAm7txvwZbeK5g3oB3DrRhnARTEjTNorVreWJomfHJHbEu2', '16Uiu2HAmPu9PZESp4keskcfDkdBvDhs1Dra1aLjfeHRCFHgQoD6L']
-    return connectTest(daemons, ids)
-  })
-})
+}


### PR DESCRIPTION
This PR replaces #32 for adding interop tests for secio and noise, since after #37 being merged using a folder structure with each key, the #32 PR got a complex task to rebase.

This PR adds exactly the same as #32 

- The connect tests can now be run with different configurations to make it easier to run those suites for both secio and noise.
- Enabled the ability to specify local daemons when running the tests to make verifying go daemon changes easier. Doing this is noted in the readme.

