### PR TITLE
test: default to noise in tests

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,7 @@ exports.getMultiaddr = (sockPath, port) => isWindows
   : ma(`/unix${path.resolve(os.tmpdir(), sockPath)}`)
 
 exports.DEFAULT_CONFIG = {
-  secio: true,
-  noise: false,
+  secio: false,
+  noise: true,
   dht: false
 }


### PR DESCRIPTION
This switches the test daemons to default to running noise instead of secio. Basic connection tests for the 3 key types are still being run for both secio and noise.


Ref:
go-libp2p defaulting to Noise https://github.com/libp2p/go-libp2p/pull/972