### PR TITLE
feat: remove secio support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ stages:
   - cov
 
 node_js:
-  - '10'
+  - '14'
+  - '15'
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=10.0.0",
+    "node": ">=14.0.0",
     "npm": ">6.0.0"
   },
   "scripts": {
@@ -40,9 +40,9 @@
     "cross-env": "^7.0.0",
     "dirty-chai": "^2.0.1",
     "go-libp2p-dep": "^0.11.0",
-    "libp2p-daemon": "^0.5.1",
-    "libp2p-daemon-client": "^0.5.0",
-    "multiaddr": "^8.0.0",
+    "libp2p-daemon": "^0.6.0",
+    "libp2p-daemon-client": "^0.6.0",
+    "multiaddr": "^9.0.0",
     "p-retry": "^4.2.0",
     "rimraf": "^3.0.0"
   },

--- a/pdd/PDD-THE-IPFS-BUNDLE.md
+++ b/pdd/PDD-THE-IPFS-BUNDLE.md
@@ -21,7 +21,7 @@ class Node extends libp2p {
           Yamux
         ],
         crypto: [
-          SECIO
+          Noise
           // TLS 1.3 (Soon™)
         ]
       },

--- a/src/daemon.js
+++ b/src/daemon.js
@@ -114,7 +114,6 @@ class Daemon {
         // we need to be in dht server mode for testing
         execOptions = ['-listen', addr, '-hostAddrs=/ip4/0.0.0.0/tcp/0,/ip4/0.0.0.0/udp/0/quic']
 
-        execOptions.push(`-secio=${options.secio}`)
         execOptions.push(`-noise=${options.noise}`)
         options.dht && execOptions.push('-dhtServer')
         options.pubsub && execOptions.push('-pubsub')
@@ -122,7 +121,6 @@ class Daemon {
       } else {
         execOptions = ['--listen', addr, '-hostAddrs=/ip4/0.0.0.0/tcp/0']
 
-        execOptions.push(`--secio=${options.secio}`)
         execOptions.push(`--noise=${options.noise}`)
         options.dht && execOptions.push('--dht')
         options.pubsub && execOptions.push('--pubsub')

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,6 @@ exports.getMultiaddr = (sockPath, port) => isWindows
   : ma(`/unix${path.resolve(os.tmpdir(), sockPath)}`)
 
 exports.DEFAULT_CONFIG = {
-  secio: false,
   noise: true,
   dht: false
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@
 
 const os = require('os')
 const path = require('path')
-const ma = require('multiaddr')
+const { Multiaddr } = require('multiaddr')
 const isWindows = os.platform() === 'win32'
 
 exports.isWindows = isWindows
@@ -12,8 +12,8 @@ exports.getSockPath = (sockPath) => isWindows
   : path.resolve(os.tmpdir(), sockPath)
 
 exports.getMultiaddr = (sockPath, port) => isWindows
-  ? ma(`/ip4/0.0.0.0/tcp/${port || 8080}`)
-  : ma(`/unix${path.resolve(os.tmpdir(), sockPath)}`)
+  ? new Multiaddr(`/ip4/0.0.0.0/tcp/${port || 8080}`)
+  : new Multiaddr(`/unix${path.resolve(os.tmpdir(), sockPath)}`)
 
 exports.DEFAULT_CONFIG = {
   noise: true,

--- a/test/connect/ed25519/index.js
+++ b/test/connect/ed25519/index.js
@@ -1,9 +1,5 @@
 'use strict'
 
-// SECIO
-require('./go2js')('secio', { secio: true, noise: false })
-require('./js2go')('secio', { secio: true, noise: false })
-
 // NOISE
-require('./go2js')('noise', { secio: false, noise: true })
-require('./js2go')('noise', { secio: false, noise: true })
+require('./go2js')('noise', { noise: true })
+require('./js2go')('noise', { noise: true })

--- a/test/connect/rsa/index.js
+++ b/test/connect/rsa/index.js
@@ -1,9 +1,5 @@
 'use strict'
 
-// SECIO
-require('./go2js')('secio', { secio: true, noise: false })
-require('./js2go')('secio', { secio: true, noise: false })
-
 // NOISE
-require('./go2js')('noise', { secio: false, noise: true })
-require('./js2go')('noise', { secio: false, noise: true })
+require('./go2js')('noise', { noise: true })
+require('./js2go')('noise', { noise: true })

--- a/test/connect/secp256k1/index.js
+++ b/test/connect/secp256k1/index.js
@@ -1,9 +1,5 @@
 'use strict'
 
-// SECIO
-require('./go2js')('secio', { secio: true, noise: false })
-require('./js2go')('secio', { secio: true, noise: false })
-
 // NOISE
-require('./go2js')('noise', { secio: false, noise: true })
-require('./js2go')('noise', { secio: false, noise: true })
+require('./go2js')('noise', { noise: true })
+require('./js2go')('noise', { noise: true })


### PR DESCRIPTION
Secio has now been completely deprecated and support has been removed from the go-libp2p daemon (in master).

Needs:
- [x] https://github.com/libp2p/js-libp2p-daemon/pull/46
- [x] https://github.com/libp2p/js-libp2p-daemon-client/pull/67