### PR TITLE
feat!: add stream tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,14 +128,16 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/daemon-client": "^2.0.1",
+    "@libp2p/daemon-client": "^3.0.0",
     "@libp2p/interface-peer-info": "^1.0.1",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/peer-id": "^1.1.8",
     "@multiformats/multiaddr": "^10.1.8",
     "it-all": "^1.0.6",
     "it-first": "^1.0.7",
+    "it-pipe": "^2.0.4",
     "multiformats": "^9.4.5",
+    "p-defer": "^4.0.0",
     "p-retry": "^5.1.0",
     "uint8arrays": "^3.0.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { connectTests } from './connect.js'
 import { dhtTests } from './dht/index.js'
 import { pubsubTests } from './pubsub/index.js'
+import { streamTests } from './streams/index.js'
 import type { DaemonClient } from '@libp2p/daemon-client'
 
 export interface Daemon {
@@ -10,6 +11,8 @@ export interface Daemon {
 
 export type NodeType = 'js' | 'go'
 export type PeerIdType = 'rsa' | 'ed25519' | 'secp256k1'
+export type PubSubRouter = 'gossipsub' | 'floodsub'
+export type Muxer = 'mplex' | 'yamux'
 
 export interface SpawnOptions {
   type: NodeType
@@ -17,7 +20,8 @@ export interface SpawnOptions {
   noise?: true
   dht?: boolean
   pubsub?: boolean
-  pubsubRouter?: 'gossipsub' | 'floodsub'
+  pubsubRouter?: PubSubRouter
+  muxer?: Muxer
 }
 
 export interface DaemonFactory {
@@ -28,10 +32,12 @@ export async function interopTests (factory: DaemonFactory) {
   await connectTests(factory)
   await dhtTests(factory)
   await pubsubTests(factory)
+  await streamTests(factory)
 }
 
 export {
   connectTests as connectInteropTests,
   dhtTests as dhtInteropTests,
-  pubsubTests as pubsubInteropTests
+  pubsubTests as pubsubInteropTests,
+  streamTests as streamInteropTests
 }

--- a/src/streams/echo.ts
+++ b/src/streams/echo.ts
@@ -1,0 +1,91 @@
+/* eslint-env mocha */
+
+import { expect } from 'aegir/chai'
+import type { Daemon, DaemonFactory, Muxer, NodeType, SpawnOptions } from '../index.js'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { pipe } from 'it-pipe'
+import all from 'it-all'
+import defer from 'p-defer'
+
+export function echoStreamTests (factory: DaemonFactory, muxer: Muxer) {
+  const nodeTypes: NodeType[] = ['js', 'go']
+
+  for (const typeA of nodeTypes) {
+    for (const typeB of nodeTypes) {
+      runEchoStreamTests(
+        factory,
+        muxer,
+        { type: typeA, muxer },
+        { type: typeB, muxer }
+      )
+    }
+  }
+}
+
+function runEchoStreamTests (factory: DaemonFactory, muxer: Muxer, optionsA: SpawnOptions, optionsB: SpawnOptions) {
+  describe(`echo streams - ${muxer}`, () => {
+    let daemons: Daemon[]
+
+    // Start Daemons
+    before(async function () {
+      this.timeout(20 * 1000)
+
+      daemons = await Promise.all([
+        factory.spawn(optionsA),
+        factory.spawn(optionsB)
+      ])
+
+      // connect them
+      const identify0 = await daemons[0].client.identify()
+
+      await daemons[1].client.connect(identify0.peerId, identify0.addrs)
+
+      // jsDaemon1 will take some time to get the peers
+      await new Promise(resolve => setTimeout(resolve, 1000))
+    })
+
+    // Stop daemons
+    after(async function () {
+      if (daemons != null) {
+        await Promise.all(
+          daemons.map(async (daemon) => await daemon.stop())
+        )
+      }
+    })
+
+    it(`${optionsA.type} sender to ${optionsB.type} listener`, async function () {
+      this.timeout(10 * 1000)
+
+      const receivingIdentity = await daemons[1].client.identify()
+      const protocol = '/echo/1.0.0'
+      const input = [uint8ArrayFromString('hello world')]
+
+      await daemons[1].client.registerStreamHandler(protocol, async (stream) => {
+        await pipe(stream, stream)
+      })
+
+      const stream = await daemons[0].client.openStream(receivingIdentity.peerId, protocol)
+
+      // without this the socket can close before we receive a response
+      const responseReceived = defer()
+
+      const output = await pipe(
+        input,
+        async function * (source) {
+          yield * source
+          await responseReceived.promise
+        },
+        stream,
+        async function * (source) {
+          for await (const buf of source) {
+            yield buf.subarray()
+            responseReceived.resolve()
+          }
+        },
+        async (source) => await all(source)
+      )
+
+      expect(output).to.deep.equal(input)
+    })
+  })
+}

--- a/src/streams/echo.ts
+++ b/src/streams/echo.ts
@@ -61,7 +61,15 @@ function runEchoStreamTests (factory: DaemonFactory, muxer: Muxer, optionsA: Spa
       const input = [uint8ArrayFromString('hello world')]
 
       await daemons[1].client.registerStreamHandler(protocol, async (stream) => {
-        await pipe(stream, stream)
+        await pipe(
+          stream,
+          async function * (source) {
+            for await (const buf of source) {
+              yield buf.subarray()
+            }
+          },
+          stream
+        )
       })
 
       const stream = await daemons[0].client.openStream(receivingIdentity.peerId, protocol)

--- a/src/streams/index.ts
+++ b/src/streams/index.ts
@@ -1,0 +1,7 @@
+import { echoStreamTests } from './echo.js'
+import type { DaemonFactory } from '../index.js'
+
+export async function streamTests (factory: DaemonFactory) {
+  await echoStreamTests(factory, 'mplex')
+  await echoStreamTests(factory, 'yamux')
+}


### PR DESCRIPTION
Adds a simple test that ensures we can send and receive data from peers.

BREAKING CHANGE: requires yamux and mplex