### PR TITLE
deps!: Update multiformats and related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,15 +132,15 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/daemon-client": "^3.0.1",
-    "@libp2p/interface-peer-info": "^1.0.3",
+    "@libp2p/daemon-client": "^4.0.0",
+    "@libp2p/interface-peer-info": "^1.0.7",
     "@libp2p/logger": "^2.0.0",
-    "@libp2p/peer-id": "^1.1.8",
+    "@libp2p/peer-id": "^2.0.0",
     "@multiformats/multiaddr": "^11.0.0",
     "it-all": "^1.0.6",
     "it-first": "^2.0.0",
     "it-pipe": "^2.0.4",
-    "multiformats": "^10.0.0",
+    "multiformats": "^11.0.0",
     "p-defer": "^4.0.0",
     "p-retry": "^5.1.0",
     "uint8arrays": "^4.0.2"


### PR DESCRIPTION
`multiformats@11.x.x` shipped with a [breaking change](https://github.com/multiformats/js-multiformats/pull/230) so update all deps using multiformats to the latest version.

Blocked By: https://github.com/libp2p/js-libp2p-daemon/pull/170