### PR TITLE
fix: remove timeouts from pubsub tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/daemon-client": "^4.0.0",
+    "@libp2p/daemon-client": "^4.1.0",
     "@libp2p/interface-peer-id": "^2.0.1",
     "@libp2p/interface-peer-info": "^1.0.7",
     "@multiformats/multiaddr": "^11.4.0",
@@ -147,6 +147,7 @@
     "multiformats": "^11.0.0",
     "p-defer": "^4.0.0",
     "p-retry": "^5.1.0",
+    "p-wait-for": "^5.0.0",
     "protons-runtime": "^4.0.2",
     "uint8arraylist": "^2.4.3",
     "uint8arrays": "^4.0.2"

--- a/src/pubsub/hybrid.ts
+++ b/src/pubsub/hybrid.ts
@@ -4,6 +4,8 @@ import { expect } from 'aegir/chai'
 import type { Daemon, DaemonFactory, NodeType, SpawnOptions } from '../index.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import first from 'it-first'
+import pWaitFor from 'p-wait-for'
+import type { IdentifyResult } from '@libp2p/daemon-client'
 
 export function hybridTests (factory: DaemonFactory): void {
   const nodeTypes: NodeType[] = ['js', 'go']
@@ -22,6 +24,7 @@ export function hybridTests (factory: DaemonFactory): void {
 function runHybridTests (factory: DaemonFactory, optionsA: SpawnOptions, optionsB: SpawnOptions): void {
   describe('pubsub.hybrid', () => {
     let daemons: Daemon[]
+    let identify1: IdentifyResult
 
     // Start Daemons
     before(async function () {
@@ -32,7 +35,7 @@ function runHybridTests (factory: DaemonFactory, optionsA: SpawnOptions, options
         factory.spawn(optionsB)
       ])
 
-      const identify1 = await daemons[1].client.identify()
+      identify1 = await daemons[1].client.identify()
       await daemons[0].client.connect(identify1.peerId, identify1.addrs)
     })
 
@@ -59,7 +62,10 @@ function runHybridTests (factory: DaemonFactory, optionsA: SpawnOptions, options
 
       const publisher = async (): Promise<void> => {
         // wait for subscription stream
-        await new Promise(resolve => setTimeout(resolve, 800))
+        await pWaitFor(async () => {
+          const peers = await daemons[0].client.pubsub.getSubscribers(topic)
+          return peers.map(p => p.toString()).includes(identify1.peerId.toString())
+        })
         await daemons[0].client.pubsub.publish(topic, data)
       }
 


### PR DESCRIPTION
Instead of waiting for 800ms for pubsub subscriptions to propagate, wait for the publisher to see the receiver in it's list of subscribers for a given topic.

This is because sometimes in CI it can taker longer than 800ms for the subs list to update which causes the tests to be flaky.