### PR TITLE
fix: wait for both peers to see each other in topic peer lists

### DIFF
--- a/src/pubsub/gossipsub.ts
+++ b/src/pubsub/gossipsub.ts
@@ -4,8 +4,7 @@ import { expect } from 'aegir/chai'
 import type { Daemon, DaemonFactory, NodeType, SpawnOptions } from '../index.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import first from 'it-first'
-import pWaitFor from 'p-wait-for'
-import type { IdentifyResult } from '@libp2p/daemon-client'
+import { waitForBothSubscribed } from './utils.js'
 
 export function gossipsubTests (factory: DaemonFactory): void {
   const nodeTypes: NodeType[] = ['js', 'go']
@@ -24,7 +23,6 @@ export function gossipsubTests (factory: DaemonFactory): void {
 function runGossipsubTests (factory: DaemonFactory, optionsA: SpawnOptions, optionsB: SpawnOptions): void {
   describe('pubsub.gossipsub', () => {
     let daemons: Daemon[]
-    let identify1: IdentifyResult
 
     // Start Daemons
     before(async function () {
@@ -35,7 +33,7 @@ function runGossipsubTests (factory: DaemonFactory, optionsA: SpawnOptions, opti
         factory.spawn(optionsB)
       ])
 
-      identify1 = await daemons[1].client.identify()
+      const identify1 = await daemons[1].client.identify()
       await daemons[0].client.connect(identify1.peerId, identify1.addrs)
     })
 
@@ -61,12 +59,7 @@ function runGossipsubTests (factory: DaemonFactory, optionsA: SpawnOptions, opti
       }
 
       const publisher = async (): Promise<void> => {
-        // wait for subscription stream
-        await pWaitFor(async () => {
-          const peers = await daemons[0].client.pubsub.getSubscribers(topic)
-          return peers.map(p => p.toString()).includes(identify1.peerId.toString())
-        })
-
+        await waitForBothSubscribed(topic, daemons[0], daemons[1])
         await daemons[0].client.pubsub.publish(topic, data)
       }
 

--- a/src/pubsub/utils.ts
+++ b/src/pubsub/utils.ts
@@ -1,0 +1,23 @@
+import pWaitFor from 'p-wait-for'
+import type { Daemon } from '..'
+
+export async function waitForBothSubscribed (topic: string, a: Daemon, b: Daemon): Promise<void> {
+  const idA = await a.client.identify()
+  const idB = await b.client.identify()
+
+  // wait for subscription stream
+  await Promise.all([
+    await pWaitFor(async () => {
+      const peers = await a.client.pubsub.getSubscribers(topic)
+      return peers.map(p => p.toString()).includes(idB.peerId.toString())
+    }, {
+      interval: 500
+    }),
+    await pWaitFor(async () => {
+      const peers = await b.client.pubsub.getSubscribers(topic)
+      return peers.map(p => p.toString()).includes(idA.peerId.toString())
+    }, {
+      interval: 500
+    })
+  ])
+}


### PR DESCRIPTION
Follow up to #88 - instead wait for both peers to see each other in their subscribed peers list.