### PR TITLE
fix: wait for gossipsub heartbeat before sending message

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "@libp2p/interface-peer-id": "^2.0.1",
     "@libp2p/interface-peer-info": "^1.0.7",
     "@multiformats/multiaddr": "^11.4.0",
+    "delay": "^5.0.0",
     "it-all": "^2.0.0",
     "it-first": "^2.0.0",
     "it-handshake": "^4.1.2",

--- a/src/pubsub/floodsub.ts
+++ b/src/pubsub/floodsub.ts
@@ -4,7 +4,7 @@ import { expect } from 'aegir/chai'
 import type { Daemon, DaemonFactory, NodeType, SpawnOptions } from '../index.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import first from 'it-first'
-import { waitForBothSubscribed } from './utils.js'
+import { waitForSubscribed } from './utils.js'
 
 export function floodsubTests (factory: DaemonFactory): void {
   const nodeTypes: NodeType[] = ['js', 'go']
@@ -61,7 +61,7 @@ function runFloodsubTests (factory: DaemonFactory, optionsA: SpawnOptions, optio
       }
 
       const publisher = async (): Promise<void> => {
-        await waitForBothSubscribed(topic, peerA, peerB)
+        await waitForSubscribed(topic, peerA, peerB)
         await peerA.client.pubsub.publish(topic, data)
       }
 

--- a/src/pubsub/gossipsub.ts
+++ b/src/pubsub/gossipsub.ts
@@ -4,7 +4,7 @@ import { expect } from 'aegir/chai'
 import type { Daemon, DaemonFactory, NodeType, SpawnOptions } from '../index.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import first from 'it-first'
-import { waitForBothSubscribed } from './utils.js'
+import { waitForSubscribed } from './utils.js'
 
 export function gossipsubTests (factory: DaemonFactory): void {
   const nodeTypes: NodeType[] = ['js', 'go']
@@ -61,7 +61,7 @@ function runGossipsubTests (factory: DaemonFactory, optionsA: SpawnOptions, opti
       }
 
       const publisher = async (): Promise<void> => {
-        await waitForBothSubscribed(topic, peerA, peerB)
+        await waitForSubscribed(topic, peerA, peerB)
         await peerA.client.pubsub.publish(topic, data)
       }
 

--- a/src/pubsub/hybrid.ts
+++ b/src/pubsub/hybrid.ts
@@ -4,7 +4,7 @@ import { expect } from 'aegir/chai'
 import type { Daemon, DaemonFactory, NodeType, SpawnOptions } from '../index.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import first from 'it-first'
-import { waitForBothSubscribed } from './utils.js'
+import { waitForSubscribed } from './utils.js'
 
 export function hybridTests (factory: DaemonFactory): void {
   const nodeTypes: NodeType[] = ['js', 'go']
@@ -61,7 +61,7 @@ function runHybridTests (factory: DaemonFactory, optionsA: SpawnOptions, options
       }
 
       const publisher = async (): Promise<void> => {
-        await waitForBothSubscribed(topic, peerA, peerB)
+        await waitForSubscribed(topic, peerA, peerB)
         await peerA.client.pubsub.publish(topic, data)
       }
 


### PR DESCRIPTION
Only wait for the sending peer to see the remote in their topic subscriber list but also wait a little bit longer for gossipsub to rebalance the mesh to increase the chances of the publisher actually sending a pubsub message to the subscriber.