### PR TITLE
fix: start daemons in series

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "clean": "aegir clean",
     "lint": "aegir lint",
     "dep-check": "aegir dep-check -i protons",
-    "build": "aegir build",
+    "build": "aegir build --bundle false",
     "postbuild": "cp src/resources/keys/*.key dist/src/resources/keys",
     "release": "aegir release"
   },

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -22,52 +22,51 @@ export function connectTests (factory: DaemonFactory): void {
 
 function runConnectTests (name: string, factory: DaemonFactory, optionsA: SpawnOptions, optionsB: SpawnOptions): void {
   describe(`connect using ${name}`, () => {
-    let daemons: Daemon[]
+    let daemonA: Daemon
+    let daemonB: Daemon
 
     // Start Daemons
     before(async function () {
       this.timeout(20 * 1000)
 
-      daemons = await Promise.all([
-        factory.spawn(optionsA),
-        factory.spawn(optionsB)
-      ])
+      daemonA = await factory.spawn(optionsA)
+      daemonB = await factory.spawn(optionsB)
     })
 
     // Stop daemons
     after(async function () {
-      if (daemons != null) {
-        await Promise.all(
-          daemons.map(async (daemon) => { await daemon.stop() })
-        )
-      }
+      await Promise.all(
+        [daemonA, daemonB]
+          .filter(Boolean)
+          .map(async d => { await d.stop() })
+      )
     })
 
     it(`${optionsA.type} peer to ${optionsB.type} peer`, async function () {
       this.timeout(10 * 1000)
 
-      const identify1 = await daemons[0].client.identify()
-      const identify2 = await daemons[1].client.identify()
+      const identify1 = await daemonA.client.identify()
+      const identify2 = await daemonB.client.identify()
 
       // verify connected peers
-      const knownPeersBeforeConnect1 = await daemons[0].client.listPeers()
+      const knownPeersBeforeConnect1 = await daemonA.client.listPeers()
       expect(knownPeersBeforeConnect1).to.have.lengthOf(0)
 
-      const knownPeersBeforeConnect2 = await daemons[1].client.listPeers()
+      const knownPeersBeforeConnect2 = await daemonB.client.listPeers()
       expect(knownPeersBeforeConnect2).to.have.lengthOf(0)
 
       // connect peers
-      await daemons[0].client.connect(identify2.peerId, identify2.addrs)
+      await daemonA.client.connect(identify2.peerId, identify2.addrs)
 
-      // daemons[0] will take some time to get the peers
+      // daemonA will take some time to get the peers
       await new Promise(resolve => setTimeout(resolve, 1000))
 
       // verify connected peers
-      const knownPeersAfterConnect1 = await daemons[0].client.listPeers()
+      const knownPeersAfterConnect1 = await daemonA.client.listPeers()
       expect(knownPeersAfterConnect1).to.have.length.greaterThanOrEqual(1)
       expect(knownPeersAfterConnect1[0].toString()).to.equal(identify2.peerId.toString())
 
-      const knownPeersAfterConnect2 = await daemons[1].client.listPeers()
+      const knownPeersAfterConnect2 = await daemonB.client.listPeers()
       expect(knownPeersAfterConnect2).to.have.length.greaterThanOrEqual(1)
       expect(knownPeersAfterConnect2[0].toString()).to.equal(identify1.peerId.toString())
     })

--- a/src/dht/content-routing.ts
+++ b/src/dht/content-routing.ts
@@ -27,25 +27,27 @@ export function contentRoutingTests (factory: DaemonFactory): void {
 
 function runContentRoutingTests (factory: DaemonFactory, optionsA: SpawnOptions, optionsB: SpawnOptions): void {
   describe('dht.contentRouting', () => {
-    let daemons: Daemon[]
+    let daemonA: Daemon
+    let daemonB: Daemon
+    let daemonC: Daemon
     let identify: IdentifyResult[]
 
     // Start Daemons
     before(async function () {
       this.timeout(20 * 1000)
 
-      daemons = await Promise.all([
-        factory.spawn(optionsA),
-        factory.spawn(optionsB),
-        factory.spawn(optionsB)
+      daemonA = await factory.spawn(optionsA)
+      daemonB = await factory.spawn(optionsB)
+      daemonC = await factory.spawn(optionsB)
+
+      identify = await Promise.all([
+        daemonA.client.identify(),
+        daemonB.client.identify(),
+        daemonC.client.identify()
       ])
 
-      identify = await Promise.all(
-        daemons.map(async d => await d.client.identify())
-      )
-
-      await daemons[0].client.connect(identify[1].peerId, identify[1].addrs)
-      await daemons[0].client.connect(identify[2].peerId, identify[2].addrs)
+      await daemonA.client.connect(identify[1].peerId, identify[1].addrs)
+      await daemonA.client.connect(identify[2].peerId, identify[2].addrs)
 
       // get the peers in the table
       await new Promise(resolve => setTimeout(resolve, 1000))
@@ -53,19 +55,19 @@ function runContentRoutingTests (factory: DaemonFactory, optionsA: SpawnOptions,
 
     // Stop daemons
     after(async function () {
-      if (daemons != null) {
-        await Promise.all(
-          daemons.map(async (daemon) => { await daemon.stop() })
-        )
-      }
+      await Promise.all(
+        [daemonA, daemonB]
+          .filter(Boolean)
+          .map(async d => { await d.stop() })
+      )
     })
 
     it(`${optionsA.type} peer to ${optionsB.type} peer`, async function () {
       const cid = CID.parse('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp39')
 
-      await daemons[0].client.dht.provide(cid)
+      await daemonA.client.dht.provide(cid)
 
-      const providers = await all(daemons[1].client.dht.findProviders(cid, 1))
+      const providers = await all(daemonB.client.dht.findProviders(cid, 1))
 
       expect(providers).to.exist()
       expect(providers.length).to.be.greaterThan(0)

--- a/src/pubsub/floodsub.ts
+++ b/src/pubsub/floodsub.ts
@@ -22,37 +22,34 @@ export function floodsubTests (factory: DaemonFactory): void {
 
 function runFloodsubTests (factory: DaemonFactory, optionsA: SpawnOptions, optionsB: SpawnOptions): void {
   describe('pubsub.floodSub', () => {
-    let daemons: Daemon[]
+    let daemonA: Daemon
+    let daemonB: Daemon
 
     // Start Daemons
     before(async function () {
       this.timeout(20 * 1000)
 
-      daemons = await Promise.all([
-        factory.spawn(optionsA),
-        factory.spawn(optionsB)
-      ])
+      daemonA = await factory.spawn(optionsA)
+      daemonB = await factory.spawn(optionsB)
 
-      const [peerA, peerB] = daemons
-      const identifyB = await peerB.client.identify()
-      await peerA.client.connect(identifyB.peerId, identifyB.addrs)
+      const identifyB = await daemonB.client.identify()
+      await daemonA.client.connect(identifyB.peerId, identifyB.addrs)
     })
 
     // Stop daemons
     after(async function () {
-      if (daemons != null) {
-        await Promise.all(
-          daemons.map(async (daemon) => { await daemon.stop() })
-        )
-      }
+      await Promise.all(
+        [daemonA, daemonB]
+          .filter(Boolean)
+          .map(async d => { await d.stop() })
+      )
     })
 
     it(`${optionsA.type} peer to ${optionsB.type} peer`, async function () {
       const topic = 'test-topic'
       const data = uint8ArrayFromString('test-data')
-      const [peerA, peerB] = daemons
 
-      const subscription = await peerB.client.pubsub.subscribe(topic)
+      const subscription = await daemonB.client.pubsub.subscribe(topic)
       const subscriber = async (): Promise<void> => {
         const message = await first(subscription.messages())
 
@@ -61,8 +58,8 @@ function runFloodsubTests (factory: DaemonFactory, optionsA: SpawnOptions, optio
       }
 
       const publisher = async (): Promise<void> => {
-        await waitForSubscribed(topic, peerA, peerB)
-        await peerA.client.pubsub.publish(topic, data)
+        await waitForSubscribed(topic, daemonA, daemonB)
+        await daemonA.client.pubsub.publish(topic, data)
       }
 
       return await Promise.all([

--- a/src/pubsub/gossipsub.ts
+++ b/src/pubsub/gossipsub.ts
@@ -22,37 +22,34 @@ export function gossipsubTests (factory: DaemonFactory): void {
 
 function runGossipsubTests (factory: DaemonFactory, optionsA: SpawnOptions, optionsB: SpawnOptions): void {
   describe('pubsub.gossipsub', () => {
-    let daemons: Daemon[]
+    let daemonA: Daemon
+    let daemonB: Daemon
 
     // Start Daemons
     before(async function () {
       this.timeout(20 * 1000)
 
-      daemons = await Promise.all([
-        factory.spawn(optionsA),
-        factory.spawn(optionsB)
-      ])
+      daemonA = await factory.spawn(optionsA)
+      daemonB = await factory.spawn(optionsB)
 
-      const [peerA, peerB] = daemons
-      const identifyB = await peerB.client.identify()
-      await peerA.client.connect(identifyB.peerId, identifyB.addrs)
+      const identifyB = await daemonB.client.identify()
+      await daemonA.client.connect(identifyB.peerId, identifyB.addrs)
     })
 
     // Stop daemons
     after(async function () {
-      if (daemons != null) {
-        await Promise.all(
-          daemons.map(async daemon => { await daemon.stop() })
-        )
-      }
+      await Promise.all(
+        [daemonA, daemonB]
+          .filter(Boolean)
+          .map(async d => { await d.stop() })
+      )
     })
 
     it(`${optionsA.type} peer to ${optionsB.type} peer`, async function () {
       const topic = 'test-topic'
       const data = uint8ArrayFromString('test-data')
-      const [peerA, peerB] = daemons
 
-      const subscription = await peerB.client.pubsub.subscribe(topic)
+      const subscription = await daemonB.client.pubsub.subscribe(topic)
       const subscriber = async (): Promise<void> => {
         const message = await first(subscription.messages())
 
@@ -61,8 +58,8 @@ function runGossipsubTests (factory: DaemonFactory, optionsA: SpawnOptions, opti
       }
 
       const publisher = async (): Promise<void> => {
-        await waitForSubscribed(topic, peerA, peerB)
-        await peerA.client.pubsub.publish(topic, data)
+        await waitForSubscribed(topic, daemonA, daemonB)
+        await daemonA.client.pubsub.publish(topic, data)
       }
 
       return await Promise.all([

--- a/src/pubsub/utils.ts
+++ b/src/pubsub/utils.ts
@@ -17,6 +17,7 @@ export async function waitForSubscribed (topic: string, a: Daemon, b: Daemon): P
     interval: 500
   })
 
-  // wait for the gossipsub heartbeat to rebalance the mesh
+  // just having a peer in the subscriber list is not a guarentee they will recieve the
+  // message - we have to also wait for the gossipsub heartbeat to rebalance the mesh
   await delay(2000)
 }

--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -29,7 +29,10 @@ function relayTest (factory: DaemonFactory, aType: NodeType, bType: NodeType, re
 
     beforeEach(async function () {
       this.timeout(20 * 1000)
-      ;[aNode, bNode, relay] = await Promise.all(opts.map(async o => await factory.spawn(o)))
+      aNode = await factory.spawn(opts[0])
+      bNode = await factory.spawn(opts[1])
+      relay = await factory.spawn(opts[2])
+
       ;[bId, relayId] = await Promise.all([bNode, relay].map(async d => await d.client.identify()))
 
       // construct a relay address
@@ -40,7 +43,11 @@ function relayTest (factory: DaemonFactory, aType: NodeType, bType: NodeType, re
     })
 
     afterEach(async function () {
-      await Promise.all([aNode, bNode, relay].map(async d => { await d.stop() }))
+      await Promise.all([aNode, bNode, relay].map(async d => {
+        if (d != null) {
+          await d.stop()
+        }
+      }))
     })
 
     it('connects', async () => {


### PR DESCRIPTION
We store references to the daemon client in the return value of `Promise.all` and use them to stop the daemons after a test run - if one or more daemons fail to start, we lose all references to daemons that started successfully so cannot stop them and the test run hangs.

Instead start them individually so we can tear down any that started successfully.

Refs: libp2p/js-libp2p#1575