### PR TITLE
feat!: test tls encryption

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1,30 +1,13 @@
 import { expect } from 'aegir/chai'
-import { keys } from './resources/keys/index.js'
-import type { Daemon, NodeType, SpawnOptions, DaemonFactory, PeerIdType, Encryption } from './index.js'
+import { runTests } from './utils/test-matrix.js'
+import type { Daemon, SpawnOptions, DaemonFactory } from './index.js'
 
 export function connectTests (factory: DaemonFactory): void {
-  const keyTypes: PeerIdType[] = ['ed25519', 'rsa', 'secp256k1']
-  const impls: NodeType[] = ['js', 'go']
-  const encrypters: Encryption[] = ['noise', 'tls']
-
-  for (const keyType of keyTypes) {
-    for (const implA of impls) {
-      for (const implB of impls) {
-        for (const encrypter of encrypters) {
-          runConnectTests(
-            `${encrypter}/${keyType}`,
-            factory,
-            { type: implA, encryption: encrypter, key: keys.go[keyType] },
-            { type: implB, encryption: encrypter, key: keys.js[keyType] }
-          )
-        }
-      }
-    }
-  }
+  runTests('connect', runConnectTests, factory)
 }
 
 function runConnectTests (name: string, factory: DaemonFactory, optionsA: SpawnOptions, optionsB: SpawnOptions): void {
-  describe(`connect using ${name}`, () => {
+  describe(name, () => {
     let daemonA: Daemon
     let daemonB: Daemon
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1,20 +1,23 @@
 import { expect } from 'aegir/chai'
 import { keys } from './resources/keys/index.js'
-import type { Daemon, NodeType, SpawnOptions, DaemonFactory, PeerIdType } from './index.js'
+import type { Daemon, NodeType, SpawnOptions, DaemonFactory, PeerIdType, Encryption } from './index.js'
 
 export function connectTests (factory: DaemonFactory): void {
   const keyTypes: PeerIdType[] = ['ed25519', 'rsa', 'secp256k1']
   const impls: NodeType[] = ['js', 'go']
+  const encrypters: Encryption[] = ['noise', 'tls']
 
   for (const keyType of keyTypes) {
     for (const implA of impls) {
       for (const implB of impls) {
-        runConnectTests(
-          `noise/${keyType}`,
-          factory,
-          { type: implA, noise: true, key: keys.go[keyType] },
-          { type: implB, noise: true, key: keys.js[keyType] }
-        )
+        for (const encrypter of encrypters) {
+          runConnectTests(
+            `${encrypter}/${keyType}`,
+            factory,
+            { type: implA, encryption: encrypter, key: keys.go[keyType] },
+            { type: implB, encryption: encrypter, key: keys.js[keyType] }
+          )
+        }
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,11 +58,12 @@ export type NodeType = 'js' | 'go'
 export type PeerIdType = 'rsa' | 'ed25519' | 'secp256k1'
 export type PubSubRouter = 'gossipsub' | 'floodsub'
 export type Muxer = 'mplex' | 'yamux'
+export type Encryption = 'noise' | 'tls'
 
 export interface SpawnOptions {
   type: NodeType
   key?: string
-  noise?: true
+  encryption?: Encryption
   dht?: boolean
   pubsub?: boolean
   pubsubRouter?: PubSubRouter

--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -15,9 +15,9 @@ export function relayTests (factory: DaemonFactory): void {
 function relayTest (factory: DaemonFactory, aType: NodeType, bType: NodeType, relayType: NodeType): void {
   describe(`${aType} to ${bType} over relay ${relayType}`, () => {
     const opts: SpawnOptions[] = [
-      { type: aType, noise: true, noListen: true },
-      { type: bType, noise: true, noListen: true },
-      { type: relayType, noise: true, relay: true }
+      { type: aType, encryption: 'noise', noListen: true },
+      { type: bType, encryption: 'noise', noListen: true },
+      { type: relayType, encryption: 'noise', relay: true }
     ]
 
     let aNode: Daemon

--- a/src/streams/echo.ts
+++ b/src/streams/echo.ts
@@ -5,25 +5,10 @@ import all from 'it-all'
 import { pipe } from 'it-pipe'
 import defer from 'p-defer'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import type { Daemon, DaemonFactory, Muxer, NodeType, SpawnOptions } from '../index.js'
+import type { Daemon, DaemonFactory, SpawnOptions } from '../index.js'
 
-export function echoStreamTests (factory: DaemonFactory, muxer: Muxer): void {
-  const nodeTypes: NodeType[] = ['js', 'go']
-
-  for (const typeA of nodeTypes) {
-    for (const typeB of nodeTypes) {
-      runEchoStreamTests(
-        factory,
-        muxer,
-        { type: typeA, muxer },
-        { type: typeB, muxer }
-      )
-    }
-  }
-}
-
-function runEchoStreamTests (factory: DaemonFactory, muxer: Muxer, optionsA: SpawnOptions, optionsB: SpawnOptions): void {
-  describe(`echo streams - ${muxer}`, () => {
+export function echoStreamTests (name: string, factory: DaemonFactory, optionsA: SpawnOptions, optionsB: SpawnOptions): void {
+  describe(name, () => {
     let daemonA: Daemon
     let daemonB: Daemon
 

--- a/src/streams/index.ts
+++ b/src/streams/index.ts
@@ -1,7 +1,7 @@
+import { runTests } from '../utils/test-matrix.js'
 import { echoStreamTests } from './echo.js'
 import type { DaemonFactory } from '../index.js'
 
 export async function streamTests (factory: DaemonFactory): Promise<void> {
-  echoStreamTests(factory, 'mplex')
-  echoStreamTests(factory, 'yamux')
+  runTests('echo', echoStreamTests, factory)
 }

--- a/src/utils/test-matrix.ts
+++ b/src/utils/test-matrix.ts
@@ -1,0 +1,31 @@
+import { keys } from '../resources/keys/index.js'
+import type { DaemonFactory, Encryption, Muxer, NodeType, PeerIdType, SpawnOptions } from '../index.js'
+
+export interface TestFunction {
+  (name: string, factory: DaemonFactory, optionsA: SpawnOptions, optionsB: SpawnOptions): void
+}
+
+export function runTests (name: string, fn: TestFunction, factory: DaemonFactory): void {
+  const keyTypes: PeerIdType[] = ['ed25519', 'rsa', 'secp256k1']
+  const impls: NodeType[] = ['js', 'go']
+  const encrypters: Encryption[] = ['noise', 'tls']
+  const muxers: Muxer[] = ['mplex', 'yamux']
+
+  for (const keyType of keyTypes) {
+    for (const implA of impls) {
+      for (const implB of impls) {
+        for (const encrypter of encrypters) {
+          // eslint-disable-next-line max-depth
+          for (const muxer of muxers) {
+            fn(
+              `${keyType}/${encrypter}/${muxer} ${name}`,
+              factory,
+              { type: implA, encryption: encrypter, key: keys.go[keyType] },
+              { type: implB, encryption: encrypter, key: keys.js[keyType] }
+            )
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds tests for tls encryption but as a major to control when it is pulled in to the js-libp2p monorepo.

BREAKING CHANGE: tls support is required

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works