### PR TITLE
feat: add webrtc-direct connect tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export type PeerIdType = 'rsa' | 'ed25519' | 'secp256k1'
 export type PubSubRouter = 'gossipsub' | 'floodsub'
 export type Muxer = 'mplex' | 'yamux'
 export type Encryption = 'noise' | 'tls'
-export type TransportType = 'tcp' | 'webtransport'
+export type TransportType = 'tcp' | 'webtransport' | 'webrtc-direct'
 
 export interface SpawnOptions {
   type: NodeType
@@ -94,4 +94,16 @@ export {
   pubsubTests as pubsubInteropTests,
   streamTests as streamInteropTests,
   relayTests as relayInteropTests
+}
+
+/**
+ * Some tests allow skipping certain configurations. When this is necessary,
+ * `DaemonFactory.spawn` should thow an instance of this error.
+ */
+export class UnsupportedError extends Error {
+  constructor (message = 'Unsupported test configuration') {
+    super(message)
+
+    this.name = 'UnsupportedError'
+  }
 }


### PR DESCRIPTION
Adds tests that use webrtc-direct transports and also an `UnsupportedError` error that can be thrown to skip the current test if it's not supported by the current platform.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works