### PR TITLE
fix: guard on nodes

### DIFF
--- a/src/dht/content-fetching.ts
+++ b/src/dht/content-fetching.ts
@@ -80,7 +80,7 @@ function runContentFetchingTests (factory: DaemonFactory, optionsA: SpawnOptions
     // Stop daemons
     after(async function () {
       await Promise.all(
-        nodes
+        (nodes ?? [])
           .filter(Boolean)
           .map(async d => { await d.stop() })
       )


### PR DESCRIPTION
If the `before` step times out, `nodes` may not be set.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works